### PR TITLE
  Make S mode 2->1 downshift behave more like in manual mode

### DIFF
--- a/src/profiles.cpp
+++ b/src/profiles.cpp
@@ -250,6 +250,9 @@ bool StandardProfile::should_downshift(GearboxGear current_gear, SensorData* sen
     float pedal_perc = ((float)sensors->pedal_pos*100)/250.0;
     float rpm_percent = (float)(sensors->input_rpm-1000)*100.0/(float)(4500-1000);
     unsigned long t =  esp_timer_get_time()/1000;
+    if (current_gear == GearboxGear::Second && sensors->input_rpm > 300 && sensors->engine_rpm > 800) {
+        return false;
+    }
     if (sensors->input_rpm < 1000) {
         return true;
     }


### PR DESCRIPTION
Make S mode 2->1 downshift behave more like in manual mode
In S mode don't downshift 1->2 when input_rpm < 300 and engine_rpm < 800