### PR TITLE
Eeprom configuration

### DIFF
--- a/include/gearbox_config.h
+++ b/include/gearbox_config.h
@@ -1,28 +1,25 @@
 #ifndef __GEARBOX_CONFIG_H_
 #define __GEARBOX_CONFIG_H_
 
-//#define LARGE_NAG // Uncomment if you have W580
 
 // https://en.wikipedia.org/wiki/Mercedes-Benz_5G-Tronic_transmission
-#ifdef LARGE_NAG
-    #define RAT_1 3.5876 // 1.64 (1->2 D_RATIO)
-    #define RAT_2 2.1862 // 1.55 (2->3 D_RATIO)
-    #define RAT_3 1.4054 // 1.41 (3->4 D_RATIO)
-    #define RAT_4 1.0000 // 1.21 (4->5 D_RATIO)
-    #define RAT_5 0.8314
-    #define RAT_R1 -3.1605
-    #define RAT_R2 -1.9259
-    #define MAX_TORQUE_RATING_NM 580
-#else
-    #define RAT_1 3.9319 // 1.63 (1->2 D_RATO)
-    #define RAT_2 2.4079 // 1.62 (2->3 D_RATO)
-    #define RAT_3 1.4857 // 1.49 (3->4 D_RATO)
-    #define RAT_4 1.0000 // 1.20 (4->5 D_RATO)
-    #define RAT_5 0.8305
-    #define RAT_R1 -3.1002
-    #define RAT_R2 -1.8986
-    #define MAX_TORQUE_RATING_NM 330
-#endif
+    #define RAT_1_LARGE 3.5876 // 1.64 (1->2 D_RATIO)
+    #define RAT_2_LARGE 2.1862 // 1.55 (2->3 D_RATIO)
+    #define RAT_3_LARGE 1.4054 // 1.41 (3->4 D_RATIO)
+    #define RAT_4_LARGE 1.0000 // 1.21 (4->5 D_RATIO)
+    #define RAT_5_LARGE 0.8314
+    #define RAT_R1_LARGE -3.1605
+    #define RAT_R2_LARGE -1.9259
+    #define MAX_TORQUE_RATING_NM_LARGE 580
+
+    #define RAT_1_SMALL 3.9319 // 1.63 (1->2 D_RATO)
+    #define RAT_2_SMALL 2.4079 // 1.62 (2->3 D_RATO)
+    #define RAT_3_SMALL 1.4857 // 1.49 (3->4 D_RATO)
+    #define RAT_4_SMALL 1.0000 // 1.20 (4->5 D_RATO)
+    #define RAT_5_SMALL 0.8305
+    #define RAT_R1_SMALL -3.1002
+    #define RAT_R2_SMALL -1.8986
+    #define MAX_TORQUE_RATING_NM_SMALL 330
 
 #define EGS52_MODE // EGS52 CAN layer
 //#define EGS53_MODE // EGS53 CAN layer

--- a/src/common_structs.h
+++ b/src/common_structs.h
@@ -107,10 +107,6 @@ typedef struct {
     uint16_t initial_mpc_pwm;
     /// SPC Ramp speed, denotes the speed of which SPC pressure will increase during the shift
     float spc_dec_speed;
-    /// MPC Ramp speed, denotes the speed of which MPC pressure will increase during the shift
-    /// IMPORTANT: This value must ALWAYS be less than spc_dec_speed, otherwise the box will
-    /// fail to shift!
-    float mpc_dec_speed;
     /// The shift solenoid required to change gears
     Solenoid* shift_solenoid;
     /// Current gear the gearbox is in as an integer
@@ -123,7 +119,7 @@ typedef struct {
 } ShiftData;
 
 #pragma GCC diagnostic ignored "-Wmissing-field-initializers" // This is ALWAYS correctly initialized in pressure_manager.cpp
-const ShiftData DEFAULT_SHIFT_DATA = { .initial_spc_pwm = 100, .initial_mpc_pwm = 100, .spc_dec_speed = 5.0, .mpc_dec_speed = 3.0};
+const ShiftData DEFAULT_SHIFT_DATA = { .initial_spc_pwm = 100, .initial_mpc_pwm = 100, .spc_dec_speed = 5.0};
 
 typedef struct {
     /**

--- a/src/common_structs.h
+++ b/src/common_structs.h
@@ -6,7 +6,7 @@
 #include "solenoids/solenoids.h"
 
 typedef int16_t pressure_map[11];
-
+typedef float rpm_modifier_map[9];
 
 template<typename T, uint8_t MAX_SIZE> struct MovingAverage {
     T readings[MAX_SIZE];
@@ -129,6 +129,38 @@ typedef struct {
     const GearRatioLimit* bounds;
     const float* ratios; // 1-5 and R1+R2
 } GearboxConfiguration;
+
+
+typedef struct {
+    pressure_map spc_1_2;
+    pressure_map mpc_1_2;
+
+    pressure_map spc_2_3;
+    pressure_map mpc_2_3;
+
+    pressure_map spc_3_4;
+    pressure_map mpc_3_4;
+
+    pressure_map spc_4_5;
+    pressure_map mpc_4_5;
+
+    pressure_map spc_5_4;
+    pressure_map mpc_5_4;
+
+    pressure_map spc_4_3;
+    pressure_map mpc_4_3;
+
+    pressure_map spc_3_2;
+    pressure_map mpc_3_2;
+
+    pressure_map spc_2_1;
+    pressure_map mpc_2_1;
+
+    pressure_map working_mpc;
+
+    rpm_modifier_map ramp_speed_multiplier;
+    rpm_modifier_map working_multiplier;
+} PressureMgrData;
 
 #pragma GCC diagnostic ignored "-Wmissing-field-initializers" // This is ALWAYS correctly initialized in pressure_manager.cpp
 const ShiftData DEFAULT_SHIFT_DATA = { .initial_spc_pwm = 100, .initial_mpc_pwm = 100, .spc_dec_speed = 5.0};

--- a/src/common_structs.h
+++ b/src/common_structs.h
@@ -113,10 +113,22 @@ typedef struct {
     uint8_t targ_g;
     /// The requested gear the gearbox will change into as an integer
     uint8_t curr_g;
-
     float torque_cut_multiplier;
-    int sip_threshold;
 } ShiftData;
+
+typedef struct {
+    float max;
+    float min;
+} GearRatioLimit;
+
+typedef const GearRatioLimit GearboxRatioBounds[7];
+typedef const float FwdRatios[7];
+
+typedef struct {
+    uint16_t max_torque;
+    const GearRatioLimit* bounds;
+    const float* ratios; // 1-5 and R1+R2
+} GearboxConfiguration;
 
 #pragma GCC diagnostic ignored "-Wmissing-field-initializers" // This is ALWAYS correctly initialized in pressure_manager.cpp
 const ShiftData DEFAULT_SHIFT_DATA = { .initial_spc_pwm = 100, .initial_mpc_pwm = 100, .spc_dec_speed = 5.0};

--- a/src/diag/can_endpoint.cpp
+++ b/src/diag/can_endpoint.cpp
@@ -62,7 +62,7 @@ void CanEndpoint::iso_tp_server_loop() {
                 default:
                     ESP_LOGE("CAN_ENDPOINT", "Invalid ISO-TP PCI %02X", msg[0]);
                     break;
-            } 
+            }
         }
 
         // Check if we have stuff to send

--- a/src/diag/diag_data.cpp
+++ b/src/diag/diag_data.cpp
@@ -2,6 +2,7 @@
 #include "sensors.h"
 #include "solenoids/solenoids.h"
 #include "perf_mon.h"
+#include <tcm_maths.h>
 
 DATA_GEARBOX_SENSORS get_gearbox_sensors(Gearbox* g) {
     DATA_GEARBOX_SENSORS ret = {};
@@ -81,5 +82,9 @@ DATA_SYS_USAGE get_sys_usage() {
     CpuStats s = get_cpu_usage();
     ret.core1_usage = s.load_core_1;
     ret.core2_usage = s.load_core_2;
+    ret.num_tasks = uxTaskGetNumberOfTasks();
+    multi_heap_info_t info;
+    heap_caps_get_info(&info, MALLOC_CAP_SPIRAM);
+    ret.free_psram = info.total_free_bytes;
     return ret;
 }

--- a/src/diag/diag_data.h
+++ b/src/diag/diag_data.h
@@ -64,6 +64,8 @@ typedef struct {
     uint16_t core1_usage;
     uint16_t core2_usage;
     uint32_t free_heap;
+    uint32_t free_psram;
+    uint32_t num_tasks;
 } __attribute__ ((packed)) DATA_SYS_USAGE;
 
 DATA_GEARBOX_SENSORS get_gearbox_sensors(Gearbox* g);

--- a/src/diag/diag_data.h
+++ b/src/diag/diag_data.h
@@ -4,6 +4,7 @@
 #include <stdint.h>
 #include "canbus/can_hal.h"
 #include "gearbox.h"
+#include "nvs/eeprom_config.h"
 
 // Diagnostic data IDs and data structures
 // used by the KWP2000 server on the TCM
@@ -18,6 +19,7 @@
 #define RLI_SOLENOID_STATUS 0x21 // Solenoid data status
 #define RLI_CAN_DATA_DUMP   0x22 // Gearbox brain logic status
 #define RLI_SYS_USAGE       0x23 // Brain usage
+#define RLI_TCM_CONFIG      0xFE // TCM configuration (AKA SCN)
 
 // Gearbox sensor struct
 typedef struct {
@@ -72,6 +74,11 @@ DATA_GEARBOX_SENSORS get_gearbox_sensors(Gearbox* g);
 DATA_SOLENOIDS get_solenoid_data();
 DATA_CANBUS_RX get_rx_can_data(AbstractCan* can_layer);
 DATA_SYS_USAGE get_sys_usage();
+
+
+// Read and write SCN config
+TCM_CORE_CONFIG get_tcm_config();
+uint8_t set_tcm_config(TCM_CORE_CONFIG cfg);
 
 
 #endif // __DIAG_DATA_H__

--- a/src/diag/kwp2000.cpp
+++ b/src/diag/kwp2000.cpp
@@ -200,6 +200,9 @@ void Kwp2000_server::server_loop() {
                 case SID_READ_DATA_LOCAL_IDENT:
                     this->process_read_data_local_ident(args_ptr, args_size);
                     break;
+                case SID_WRITE_DATA_BY_LOCAL_IDENT:
+                    this->process_write_data_by_local_ident(args_ptr, args_size);
+                    break;
                 case SID_READ_MEM_BY_ADDRESS:
                     this->process_read_mem_address(args_ptr, args_size);
                     break;
@@ -215,6 +218,7 @@ void Kwp2000_server::server_loop() {
                 case SID_REQUEST_ROUTINE_RESULTS_BY_LOCAL_IDENT:
                     this->process_request_routine_resutls_by_local_ident(args_ptr, args_size);
                     break;
+
                 default:
                     ESP_LOGW("KWP_HANDLE_REQ", "Requested SID %02X is not supported", rx_msg.data[0]);
                     make_diag_neg_msg(rx_msg.data[0], NRC_SERVICE_NOT_SUPPORTED);
@@ -293,7 +297,7 @@ void Kwp2000_server::process_ecu_reset(uint8_t* args, uint16_t arg_len) {
                 this->reboot_pending = true;
                 make_diag_pos_msg(SID_ECU_RESET, nullptr, 0);
             } else {
-                make_diag_neg_msg(SID_ECU_RESET, NRC_SUB_FUNC_NOT_SUPPORTED_INVALID_FORMAT);
+                make_diag_neg_msg(SID_ECU_RESET, NRC_REQUEST_OUT_OF_RANGE);
             }
         }
     } else {
@@ -373,7 +377,7 @@ void Kwp2000_server::process_read_ecu_ident(uint8_t* args, uint16_t arg_len) {
     } else if (args[0] == 0x90) { // VIN current
         make_diag_pos_msg(SID_READ_ECU_IDENT, 0x90, (const uint8_t*)"ULTIMATENAG52ESP0", 17);
     } else {
-        make_diag_neg_msg(SID_READ_ECU_IDENT, NRC_SUB_FUNC_NOT_SUPPORTED_INVALID_FORMAT);
+        make_diag_neg_msg(SID_READ_ECU_IDENT, NRC_REQUEST_OUT_OF_RANGE);
     }
 }
 
@@ -407,9 +411,11 @@ void Kwp2000_server::process_read_data_local_ident(uint8_t* args, uint16_t arg_l
     } else if (args[0] == RLI_SYS_USAGE) {
         DATA_SYS_USAGE r = get_sys_usage();
         make_diag_pos_msg(SID_READ_DATA_LOCAL_IDENT, RLI_SYS_USAGE, (uint8_t*)&r, sizeof(DATA_SYS_USAGE));
+    } else if (args[0] == RLI_TCM_CONFIG) {
+        TCM_CORE_CONFIG r = get_tcm_config();
+        make_diag_pos_msg(SID_READ_DATA_LOCAL_IDENT, RLI_TCM_CONFIG, (uint8_t*)&r, sizeof(TCM_CORE_CONFIG));
     }
     else {
-
         // EGS52 emulation
 #ifdef EGS52_MODE
         if (args[0] == RLI_31) {
@@ -417,7 +423,7 @@ void Kwp2000_server::process_read_data_local_ident(uint8_t* args, uint16_t arg_l
             return make_diag_pos_msg(SID_READ_DATA_LOCAL_IDENT, RLI_31, (uint8_t*)&r, sizeof(RLI_31_DATA));
         }
 #endif
-        make_diag_neg_msg(SID_READ_DATA_LOCAL_IDENT, NRC_SUB_FUNC_NOT_SUPPORTED_INVALID_FORMAT);
+        make_diag_neg_msg(SID_READ_DATA_LOCAL_IDENT, NRC_REQUEST_OUT_OF_RANGE);
     }
     
 }
@@ -462,7 +468,6 @@ void Kwp2000_server::process_write_data_by_ident(uint8_t* args, uint16_t arg_len
 
 }
 void Kwp2000_server::process_ioctl_by_local_ident(uint8_t* args, uint16_t arg_len) {
-
 }
 void Kwp2000_server::process_start_routine_by_local_ident(uint8_t* args, uint16_t arg_len) {
     if (this->session_mode != SESSION_EXTENDED && this->session_mode != SESSION_CUSTOM_UN52) {
@@ -535,7 +540,32 @@ void Kwp2000_server::process_transfer_exit(uint8_t* args, uint16_t arg_len) {
 
 }
 void Kwp2000_server::process_write_data_by_local_ident(uint8_t* args, uint16_t arg_len) {
-
+    if (
+        this->session_mode == SESSION_EXTENDED ||
+        this->session_mode == SESSION_REPROGRAMMING ||
+        this->session_mode == SESSION_STANDBY ||
+        this->session_mode == SESSION_CUSTOM_UN52
+    ) {
+        if (args[0] == RLI_TCM_CONFIG) {
+            if (arg_len-1 != sizeof(TCM_CORE_CONFIG)) {
+                make_diag_neg_msg(SID_WRITE_DATA_BY_LOCAL_IDENT, NRC_SUB_FUNC_NOT_SUPPORTED_INVALID_FORMAT);
+            } else {
+                // TCM Core config size ok
+                TCM_CORE_CONFIG cfg;
+                memcpy(&cfg, &args[1], sizeof(TCM_CORE_CONFIG));
+                uint8_t res = set_tcm_config(cfg);
+                if (res == 0x00) {
+                    make_diag_pos_msg(SID_WRITE_DATA_BY_LOCAL_IDENT, RLI_TCM_CONFIG, nullptr, 0);
+                } else {
+                    make_diag_neg_msg(SID_WRITE_DATA_BY_LOCAL_IDENT, res);
+                }
+            }
+        } else {
+            make_diag_neg_msg(SID_WRITE_DATA_BY_LOCAL_IDENT, NRC_REQUEST_OUT_OF_RANGE);
+        }
+    } else  {
+        make_diag_neg_msg(SID_WRITE_DATA_BY_LOCAL_IDENT, NRC_SERVICE_NOT_SUPPORTED_IN_ACTIVE_DIAG_SESSION);
+    }
 }
 void Kwp2000_server::process_write_mem_by_address(uint8_t* args, uint16_t arg_len) {
 

--- a/src/diag/kwp2000.h
+++ b/src/diag/kwp2000.h
@@ -10,6 +10,7 @@
 #include "canbus/can_hal.h"
 #include "gearbox_config.h"
 #include "perf_mon.h"
+#include "esp32/spiram.h"
 
 // Ident data
 

--- a/src/gearbox.cpp
+++ b/src/gearbox.cpp
@@ -244,11 +244,7 @@ int find_target_ratio(int targ_gear, FwdRatios ratios) {
 
 #define SHIFT_TIMEOUT_MS 3000 // If a shift hasn't occurred after this much time, we assume shift has failed!
 
-#ifdef BLUE_SOLENOIDS
-    #define SHIFT_DELAY_MS 60 // 50% slower ramping for blue solenoids
-#else
-    #define SHIFT_DELAY_MS 40
-#endif
+#define SHIFT_DELAY_MS 50 // 50% slower ramping for blue solenoids
 
 /**
  * @brief Used to shift between forward gears

--- a/src/gearbox.h
+++ b/src/gearbox.h
@@ -24,11 +24,6 @@
 
 #define OVERSPEED_RPM 15000
 
-typedef struct {
-    float max;
-    float min;
-} GearRatioLimit;
-
 #define ATF_TEMP_SAMPLES 20
 struct TempSampleData {
     int samples[ATF_TEMP_SAMPLES];
@@ -38,14 +33,44 @@ struct TempSampleData {
 
 #define MAX_LIMIT 0.10 // 10% drift
 
-const static GearRatioLimit GEAR_RATIO_LIMITS[7] {
-    GearRatioLimit { .max = RAT_1*(1.0+MAX_LIMIT), .min = RAT_1*(1.0-MAX_LIMIT) }, // 1
-    GearRatioLimit { .max = RAT_2*(1.0+MAX_LIMIT), .min = RAT_2*(1.0-MAX_LIMIT) }, // 2
-    GearRatioLimit { .max = RAT_3*(1.0+MAX_LIMIT), .min = RAT_3*(1.0-MAX_LIMIT) }, // 3
-    GearRatioLimit { .max = RAT_4*(1.0+MAX_LIMIT), .min = RAT_4*(1.0-MAX_LIMIT) }, // 4
-    GearRatioLimit { .max = RAT_5*(1.0+MAX_LIMIT/2), .min = RAT_5*(1.0-MAX_LIMIT/2) }, // 5 (Half tolorance so no overlap with 4th gear)
-    GearRatioLimit { .max = RAT_R1*(1.0-MAX_LIMIT), .min = RAT_R1*(1.0+MAX_LIMIT) }, // R1
-    GearRatioLimit { .max = RAT_R2*(1.0-MAX_LIMIT), .min = RAT_R2*(1.0+MAX_LIMIT) }, // R2
+const static GearRatioLimit GEAR_RATIO_LIMITS_SMALL[7] {
+    GearRatioLimit { .max = RAT_1_SMALL*(1.0+MAX_LIMIT), .min = RAT_1_SMALL*(1.0-MAX_LIMIT) }, // 1
+    GearRatioLimit { .max = RAT_2_SMALL*(1.0+MAX_LIMIT), .min = RAT_2_SMALL*(1.0-MAX_LIMIT) }, // 2
+    GearRatioLimit { .max = RAT_3_SMALL*(1.0+MAX_LIMIT), .min = RAT_3_SMALL*(1.0-MAX_LIMIT) }, // 3
+    GearRatioLimit { .max = RAT_4_SMALL*(1.0+MAX_LIMIT), .min = RAT_4_SMALL*(1.0-MAX_LIMIT) }, // 4
+    GearRatioLimit { .max = RAT_5_SMALL*(1.0+MAX_LIMIT/2), .min = RAT_5_SMALL*(1.0-MAX_LIMIT/2) }, // 5 (Half tolorance so no overlap with 4th gear)
+    GearRatioLimit { .max = RAT_R1_SMALL*(1.0-MAX_LIMIT), .min = RAT_R1_SMALL*(1.0+MAX_LIMIT) }, // R1
+    GearRatioLimit { .max = RAT_R2_SMALL*(1.0-MAX_LIMIT), .min = RAT_R2_SMALL*(1.0+MAX_LIMIT) }, // R2
+};
+
+const static GearRatioLimit GEAR_RATIO_LIMITS_LARGE[7] {
+    GearRatioLimit { .max = RAT_1_LARGE*(1.0+MAX_LIMIT), .min = RAT_1_LARGE*(1.0-MAX_LIMIT) }, // 1
+    GearRatioLimit { .max = RAT_2_LARGE*(1.0+MAX_LIMIT), .min = RAT_2_LARGE*(1.0-MAX_LIMIT) }, // 2
+    GearRatioLimit { .max = RAT_3_LARGE*(1.0+MAX_LIMIT), .min = RAT_3_LARGE*(1.0-MAX_LIMIT) }, // 3
+    GearRatioLimit { .max = RAT_4_LARGE*(1.0+MAX_LIMIT), .min = RAT_4_LARGE*(1.0-MAX_LIMIT) }, // 4
+    GearRatioLimit { .max = RAT_5_LARGE*(1.0+MAX_LIMIT/2), .min = RAT_5_LARGE*(1.0-MAX_LIMIT/2) }, // 5 (Half tolorance so no overlap with 4th gear)
+    GearRatioLimit { .max = RAT_R1_LARGE*(1.0-MAX_LIMIT), .min = RAT_R1_LARGE*(1.0+MAX_LIMIT) }, // R1
+    GearRatioLimit { .max = RAT_R2_LARGE*(1.0-MAX_LIMIT), .min = RAT_R2_LARGE*(1.0+MAX_LIMIT) }, // R2
+};
+
+const static FwdRatios RATIOS_LARGE {
+    RAT_1_LARGE,
+    RAT_2_LARGE,
+    RAT_3_LARGE,
+    RAT_4_LARGE,
+    RAT_5_LARGE,
+    RAT_R1_LARGE,
+    RAT_R2_LARGE
+};
+
+const static FwdRatios RATIOS_SMALL {
+    RAT_1_SMALL,
+    RAT_2_SMALL,
+    RAT_3_SMALL,
+    RAT_4_SMALL,
+    RAT_5_SMALL,
+    RAT_R1_SMALL,
+    RAT_R2_SMALL
 };
 
 class Gearbox {
@@ -106,6 +131,7 @@ private:
     bool control_solenoids = true;
     PressureManager* pressure_mgr = nullptr;
     ShifterPosition shifter_pos = ShifterPosition::SignalNotAvaliable;
+    GearboxConfiguration gearboxConfig;
 };
 
 #endif

--- a/src/gearbox.h
+++ b/src/gearbox.h
@@ -99,6 +99,8 @@ private:
     bool flaring = false;
     int gear_disagree_count = 0;
     unsigned long last_tcc_adjust_time = 0;
+    int mpc_offset = 0;
+    int mpc_working = 0;
     TorqueConverter* tcc = nullptr;
     TempSampleData temp_data;
     bool control_solenoids = true;

--- a/src/gearbox.h
+++ b/src/gearbox.h
@@ -18,7 +18,6 @@
 
 // TODO Auto-set these based on CAN data about engine type
 // 4000 is safe for now as it stops us over-revving diesel!
-#define REDLINE_RPM 4000
 #define STALL_RPM 700
 #define MIN_WORKING_RPM 1000
 
@@ -87,6 +86,7 @@ public:
         uint16_t get_gear_ratio() {
         return this->sensor_data.gear_ratio * 100;
     }
+    static uint16_t redline_rpm;
 private:
     ShiftResponse elapse_shift(ProfileGearChange req_lookup, AbstractProfile* profile, bool is_upshift);
     bool calcGearFromRatio(bool is_reverse);
@@ -132,6 +132,7 @@ private:
     PressureManager* pressure_mgr = nullptr;
     ShifterPosition shifter_pos = ShifterPosition::SignalNotAvaliable;
     GearboxConfiguration gearboxConfig;
+    float diff_ratio_f;
 };
 
 #endif

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -54,21 +54,27 @@ SPEAKER_POST_CODE setup_tcm()
         return SPEAKER_POST_CODE::SOLENOID_FAIL;
     }
 
-    profiles[0] = manual;
-    profiles[1] = agility;
-    profiles[2] = comfort;
-    profiles[3] = standard;
-    profiles[4] = winter;
+    profiles[0] = standard;
+    profiles[1] = comfort;
+    profiles[2] = winter;
+    profiles[3] = agility;
+    profiles[4] = manual;
 
     if (!EEPROM::init_eeprom()) {
         return SPEAKER_POST_CODE::EEPROM_FAIL;
+    }
+
+    // Read profile ID on startup based on TCM config
+    profile_id = VEHICLE_CONFIG.default_profile;
+    if (profile_id > 4) {
+        profile_id = 0;
     }
 
     gearbox = new Gearbox();
     if (!gearbox->start_controller()) {
         return SPEAKER_POST_CODE::CONTROLLER_FAIL;
     }
-    gearbox->set_profile(profiles[0]);
+    gearbox->set_profile(profiles[profile_id]);
     return SPEAKER_POST_CODE::INIT_OK;
 }
 
@@ -84,7 +90,7 @@ void err_beep_loop(void* a) {
         egs_can_hal->set_display_msg(GearboxMessage::VisitWorkshop);
         egs_can_hal->set_gearbox_ok(false);
         while(1) {
-            spkr.post(p);
+            //spkr.post(p);
             vTaskDelay(2000/portTICK_PERIOD_MS);
         }
         vTaskDelete(NULL);

--- a/src/nvs/eeprom_config.cpp
+++ b/src/nvs/eeprom_config.cpp
@@ -94,7 +94,7 @@ bool EEPROM::read_core_config(TCM_CORE_CONFIG* dest) {
             .is_large_nag = 0,
 #endif
             .diff_ratio = DIFF_RATIO,
-            .wheel_diameter = TYRE_SIZE_MM,
+            .wheel_circumference = TYRE_SIZE_MM,
 #ifdef FOUR_MATIC
             .is_four_matic = 1,
             .transfer_case_high_ratio = TC_RATIO_HIGH,

--- a/src/nvs/eeprom_config.h
+++ b/src/nvs/eeprom_config.h
@@ -14,34 +14,29 @@
 
 #define NVS_PARTITION_USER_CFG "tcm_user_config"
 #define NVS_UCFG_KEY_PROFILE "LAST_PROFILE"
-#define NVS_KEY_TCC_ADAPTATION "TCC_ADAPTATION"
-
 #define NVS_KEY_GEAR_ADAPTATION "GEAR_ADAPTATION"
 
 typedef struct {
-    bool is_large_nag;
+    uint8_t is_large_nag;
     uint16_t diff_ratio;
     uint16_t wheel_diameter;
-    bool is_four_matic;
+    uint8_t is_four_matic;
     uint16_t transfer_case_high_ratio;
     uint16_t transfer_case_low_ratio;
-} EEPROM_CORE_SCN_CONFIG;
-
-struct TccAdaptationData { // 1 per gear
-    // -40C - 120C (16 steps)
-    bool learned[17];
-    uint16_t slip_values[17]; // Where slip is (100-200RPM) (Torque is 50-120Nm)
-};
+    uint8_t default_profile;
+    uint16_t red_line_rpm_diesel;
+    uint16_t red_line_rpm_petrol;
+    uint8_t engine_type; // 0 for diesel, 1 for petrol
+} __attribute__ ((packed)) TCM_CORE_CONFIG;
 
 namespace EEPROM {
     bool init_eeprom();
     uint8_t get_last_profile();
-    bool read_core_scn_config(EEPROM_CORE_SCN_CONFIG* dest);
-    bool save_core_scn_config(EEPROM_CORE_SCN_CONFIG* write);
-    bool save_nvs_tcc_adaptation(TccAdaptationData* read_location, size_t store_size);
+    bool read_core_config(TCM_CORE_CONFIG* dest);
+    bool save_core_config(TCM_CORE_CONFIG* write);
 };
 
 #define NUM_GEARS 5
-extern TccAdaptationData torque_converter_adaptation[NUM_GEARS];
+extern TCM_CORE_CONFIG VEHICLE_CONFIG;
 
 #endif

--- a/src/nvs/eeprom_config.h
+++ b/src/nvs/eeprom_config.h
@@ -19,7 +19,7 @@
 typedef struct {
     uint8_t is_large_nag;
     uint16_t diff_ratio;
-    uint16_t wheel_diameter;
+    uint16_t wheel_circumference;
     uint8_t is_four_matic;
     uint16_t transfer_case_high_ratio;
     uint16_t transfer_case_low_ratio;

--- a/src/pressure_manager.cpp
+++ b/src/pressure_manager.cpp
@@ -60,21 +60,51 @@ uint16_t find_mpc_pressure(const pressure_map map, SensorData* sensors) {
     return locate_pressure_map_value(map, load);
 }
 
+#define COPY_MAP(name) \
+    memcpy(this->map_data.name, large_nag ? &name##_large : &name##_small, sizeof(pressure_map));
+
+PressureManager::PressureManager(SensorData* sensor_ptr) {
+    this->sensor_data = sensor_ptr;
+    this->adapt_map = new AdaptationMap();
+    this->map_data = PressureMgrData{};
+    bool large_nag = VEHICLE_CONFIG.is_large_nag;
+    COPY_MAP(mpc_1_2)
+    COPY_MAP(spc_1_2)
+    COPY_MAP(mpc_2_3)
+    COPY_MAP(spc_2_3)
+    COPY_MAP(mpc_3_4)
+    COPY_MAP(spc_3_4)
+    COPY_MAP(mpc_4_5)
+    COPY_MAP(spc_4_5)
+    COPY_MAP(mpc_5_4)
+    COPY_MAP(spc_5_4)
+    COPY_MAP(mpc_4_3)
+    COPY_MAP(spc_4_3)
+    COPY_MAP(mpc_3_2)
+    COPY_MAP(spc_3_2)
+    COPY_MAP(mpc_2_1)
+    COPY_MAP(spc_2_1)
+
+    memcpy(this->map_data.ramp_speed_multiplier, rpm_normalizer, sizeof(rpm_modifier_map));
+    memcpy(this->map_data.working_multiplier, rpm_working_normalizer, sizeof(rpm_modifier_map));
+    memcpy(this->map_data.working_mpc, working_norm_pressure, sizeof(pressure_map));
+}
+
 uint16_t PressureManager::find_working_mpc_pressure(GearboxGear curr_g, SensorData* sensors, int max_rated_torque) {
     int torque = sensors->static_torque;
     if (torque < 0) {
         torque *= -1;
     }
     int torque_load = (torque*100/max_rated_torque);
-    uint16_t raw = locate_pressure_map_value(working_norm_pressure, torque_load);
+    uint16_t raw = locate_pressure_map_value(map_data.working_mpc, torque_load);
     uint16_t engine_rpm = sensors->engine_rpm;
-    if (engine_rpm <= 0) { return rpm_normalizer[0]; }
-    else if (engine_rpm > 8000) { return rpm_normalizer[8]; }
+    if (engine_rpm <= 0) { return map_data.working_multiplier[0]; }
+    else if (engine_rpm > 8000) { return map_data.working_multiplier[8]; }
     int min = engine_rpm/1000;
     int max = min+1;
-    float dy = rpm_working_normalizer[max] - rpm_working_normalizer[min];
+    float dy = map_data.working_multiplier[max] - map_data.working_multiplier[min];
     float dx = (max-min)*1000;
-    return raw*(rpm_working_normalizer[min] + ((dy/dx)) * (engine_rpm-(min*1000)));
+    return raw*(map_data.working_multiplier[min] + ((dy/dx)) * (engine_rpm-(min*1000)));
 }
 
 float PressureManager::get_tcc_temp_multiplier(int atf_temp) {
@@ -85,57 +115,57 @@ ShiftData PressureManager::get_shift_data(SensorData* sensors, ProfileGearChange
     ShiftData sd; 
     switch (shift_request) {
         case ProfileGearChange::ONE_TWO:
-            sd.initial_spc_pwm = find_spc_pressure(spc_1_2, this->sensor_data);
-            sd.initial_mpc_pwm = find_mpc_pressure(mpc_1_2, this->sensor_data);
+            sd.initial_spc_pwm = find_spc_pressure(map_data.spc_1_2, this->sensor_data);
+            sd.initial_mpc_pwm = find_mpc_pressure(map_data.mpc_1_2, this->sensor_data);
             sd.targ_g = 2; sd.curr_g = 1;
             sd.shift_solenoid = sol_y3;
             sd.torque_cut_multiplier = 0.8;
             break;
         case ProfileGearChange::TWO_THREE:
-            sd.initial_spc_pwm = find_spc_pressure(spc_2_3, this->sensor_data);
-            sd.initial_mpc_pwm = find_mpc_pressure(mpc_2_3, this->sensor_data);
+            sd.initial_spc_pwm = find_spc_pressure(map_data.spc_2_3, this->sensor_data);
+            sd.initial_mpc_pwm = find_mpc_pressure(map_data.mpc_2_3, this->sensor_data);
             sd.targ_g = 3; sd.curr_g = 2;
             sd.shift_solenoid = sol_y5;
             sd.torque_cut_multiplier = 0.8;
             break;
         case ProfileGearChange::THREE_FOUR:
-            sd.initial_spc_pwm = find_spc_pressure(spc_3_4, this->sensor_data);
-            sd.initial_mpc_pwm = find_mpc_pressure(mpc_3_4, this->sensor_data);
+            sd.initial_spc_pwm = find_spc_pressure(map_data.spc_3_4, this->sensor_data);
+            sd.initial_mpc_pwm = find_mpc_pressure(map_data.mpc_3_4, this->sensor_data);
             sd.targ_g = 4; sd.curr_g = 3;
             sd.shift_solenoid = sol_y4;
             sd.torque_cut_multiplier = 0.8;
             break;
         case ProfileGearChange::FOUR_FIVE:
-            sd.initial_spc_pwm = find_spc_pressure(spc_4_5, this->sensor_data);
-            sd.initial_mpc_pwm = find_mpc_pressure(mpc_4_5, this->sensor_data);
+            sd.initial_spc_pwm = find_spc_pressure(map_data.spc_4_5, this->sensor_data);
+            sd.initial_mpc_pwm = find_mpc_pressure(map_data.mpc_4_5, this->sensor_data);
             sd.targ_g = 5; sd.curr_g = 4;
             sd.shift_solenoid = sol_y3;
             sd.torque_cut_multiplier = 0.8;
             break;
         case ProfileGearChange::FIVE_FOUR:
-            sd.initial_spc_pwm = find_spc_pressure(spc_5_4, this->sensor_data);
-            sd.initial_mpc_pwm = find_mpc_pressure(mpc_5_4, this->sensor_data);
+            sd.initial_spc_pwm = find_spc_pressure(map_data.spc_5_4, this->sensor_data);
+            sd.initial_mpc_pwm = find_mpc_pressure(map_data.mpc_5_4, this->sensor_data);
             sd.targ_g = 4; sd.curr_g = 5;
             sd.shift_solenoid = sol_y3;
             sd.torque_cut_multiplier = 0.9;
             break;
         case ProfileGearChange::FOUR_THREE:
-            sd.initial_spc_pwm = find_spc_pressure(spc_4_3, this->sensor_data);
-            sd.initial_mpc_pwm = find_mpc_pressure(mpc_4_3, this->sensor_data);
+            sd.initial_spc_pwm = find_spc_pressure(map_data.spc_4_3, this->sensor_data);
+            sd.initial_mpc_pwm = find_mpc_pressure(map_data.mpc_4_3, this->sensor_data);
             sd.targ_g = 3; sd.curr_g = 4;
             sd.shift_solenoid = sol_y4;
             sd.torque_cut_multiplier = 0.9;
             break;
         case ProfileGearChange::THREE_TWO:
-            sd.initial_spc_pwm = find_spc_pressure(spc_3_2, this->sensor_data);
-            sd.initial_mpc_pwm = find_mpc_pressure(mpc_3_2, this->sensor_data);
+            sd.initial_spc_pwm = find_spc_pressure(map_data.spc_3_2, this->sensor_data);
+            sd.initial_mpc_pwm = find_mpc_pressure(map_data.mpc_3_2, this->sensor_data);
             sd.targ_g = 2; sd.curr_g = 3;
             sd.shift_solenoid = sol_y5;
             sd.torque_cut_multiplier = 0.9;
             break;
         case ProfileGearChange::TWO_ONE:
-            sd.initial_spc_pwm = find_spc_pressure(spc_2_1, this->sensor_data);
-            sd.initial_mpc_pwm = find_mpc_pressure(mpc_2_1, this->sensor_data);
+            sd.initial_spc_pwm = find_spc_pressure(map_data.spc_2_1, this->sensor_data);
+            sd.initial_mpc_pwm = find_mpc_pressure(map_data.mpc_2_1, this->sensor_data);
             sd.targ_g = 1; sd.curr_g = 2;
             sd.shift_solenoid = sol_y3;
             sd.torque_cut_multiplier = 0.9;

--- a/src/pressure_manager.cpp
+++ b/src/pressure_manager.cpp
@@ -1,6 +1,6 @@
 #include "pressure_manager.h"
 
-
+/*
 float find_temp_multiplier(int temp_c) {
     int temp_raw = temp_c+50;
     if (temp_raw < 0) { return pressure_temp_normalizer[0]; }
@@ -11,6 +11,7 @@ float find_temp_multiplier(int temp_c) {
     float dx = (max-min)*10;
     return (pressure_temp_normalizer[min] + ((dy/dx)) * (temp_raw-(min*10)));
 }
+*/
 
 float find_temp_ramp_speed_multiplier(int temp_c) {
     int temp_raw = temp_c+50;
@@ -47,7 +48,7 @@ inline uint16_t locate_pressure_map_value(const pressure_map map, int percent) {
 
 uint16_t find_spc_pressure(const pressure_map map, SensorData* sensors) {
     int load = (sensors->pedal_pos*100/250);
-    return locate_pressure_map_value(map, load) * find_temp_multiplier(sensors->atf_temp);
+    return locate_pressure_map_value(map, load); //* find_temp_multiplier(sensors->atf_temp);
 }
 
 uint16_t find_mpc_pressure(const pressure_map map, SensorData* sensors) {
@@ -77,7 +78,7 @@ uint16_t PressureManager::find_working_mpc_pressure(GearboxGear curr_g, SensorDa
 }
 
 float PressureManager::get_tcc_temp_multiplier(int atf_temp) {
-    return find_temp_multiplier(atf_temp);
+    return 1.0/find_temp_ramp_speed_multiplier(atf_temp);
 }
 
 ShiftData PressureManager::get_shift_data(SensorData* sensors, ProfileGearChange shift_request, ShiftCharacteristics chars) {
@@ -152,13 +153,5 @@ ShiftData PressureManager::get_shift_data(SensorData* sensors, ProfileGearChange
     //if (this->adapt_map != nullptr) {
     //    sd.initial_spc_pwm += adapt_map->get_adaptation_offset(sensors, shift_request);
     //}
-    if (sd.targ_g < sd.curr_g) {
-        sd.spc_dec_speed *= 0.75; // Make downshifting a little smoother
-    }
-    sd.mpc_dec_speed = sd.spc_dec_speed/2.0; // For now
     return sd;
-}
-
-float get_tcc_temp_multiplier(int atf_temp) {
-    return find_temp_multiplier(atf_temp);
 }

--- a/src/pressure_manager.cpp
+++ b/src/pressure_manager.cpp
@@ -60,12 +60,12 @@ uint16_t find_mpc_pressure(const pressure_map map, SensorData* sensors) {
     return locate_pressure_map_value(map, load);
 }
 
-uint16_t PressureManager::find_working_mpc_pressure(GearboxGear curr_g, SensorData* sensors) {
+uint16_t PressureManager::find_working_mpc_pressure(GearboxGear curr_g, SensorData* sensors, int max_rated_torque) {
     int torque = sensors->static_torque;
     if (torque < 0) {
         torque *= -1;
     }
-    int torque_load = (torque*100/MAX_TORQUE_RATING_NM);
+    int torque_load = (torque*100/max_rated_torque);
     uint16_t raw = locate_pressure_map_value(working_norm_pressure, torque_load);
     uint16_t engine_rpm = sensors->engine_rpm;
     if (engine_rpm <= 0) { return rpm_normalizer[0]; }
@@ -89,32 +89,28 @@ ShiftData PressureManager::get_shift_data(SensorData* sensors, ProfileGearChange
             sd.initial_mpc_pwm = find_mpc_pressure(mpc_1_2, this->sensor_data);
             sd.targ_g = 2; sd.curr_g = 1;
             sd.shift_solenoid = sol_y3;
-            sd.torque_cut_multiplier = TC_1_2;
-            sd.sip_threshold = SIP_1_2;
+            sd.torque_cut_multiplier = 0.8;
             break;
         case ProfileGearChange::TWO_THREE:
             sd.initial_spc_pwm = find_spc_pressure(spc_2_3, this->sensor_data);
             sd.initial_mpc_pwm = find_mpc_pressure(mpc_2_3, this->sensor_data);
             sd.targ_g = 3; sd.curr_g = 2;
             sd.shift_solenoid = sol_y5;
-            sd.torque_cut_multiplier = TC_2_3;
-            sd.sip_threshold = SIP_2_3;
+            sd.torque_cut_multiplier = 0.8;
             break;
         case ProfileGearChange::THREE_FOUR:
             sd.initial_spc_pwm = find_spc_pressure(spc_3_4, this->sensor_data);
             sd.initial_mpc_pwm = find_mpc_pressure(mpc_3_4, this->sensor_data);
             sd.targ_g = 4; sd.curr_g = 3;
             sd.shift_solenoid = sol_y4;
-            sd.torque_cut_multiplier = TC_3_4;
-            sd.sip_threshold = SIP_3_4;
+            sd.torque_cut_multiplier = 0.8;
             break;
         case ProfileGearChange::FOUR_FIVE:
             sd.initial_spc_pwm = find_spc_pressure(spc_4_5, this->sensor_data);
             sd.initial_mpc_pwm = find_mpc_pressure(mpc_4_5, this->sensor_data);
             sd.targ_g = 5; sd.curr_g = 4;
             sd.shift_solenoid = sol_y3;
-            sd.torque_cut_multiplier = TC_4_5;
-            sd.sip_threshold = SIP_4_5;
+            sd.torque_cut_multiplier = 0.8;
             break;
         case ProfileGearChange::FIVE_FOUR:
             sd.initial_spc_pwm = find_spc_pressure(spc_5_4, this->sensor_data);
@@ -122,7 +118,6 @@ ShiftData PressureManager::get_shift_data(SensorData* sensors, ProfileGearChange
             sd.targ_g = 4; sd.curr_g = 5;
             sd.shift_solenoid = sol_y3;
             sd.torque_cut_multiplier = 0.9;
-            sd.sip_threshold = SIP_5_4;
             break;
         case ProfileGearChange::FOUR_THREE:
             sd.initial_spc_pwm = find_spc_pressure(spc_4_3, this->sensor_data);
@@ -130,7 +125,6 @@ ShiftData PressureManager::get_shift_data(SensorData* sensors, ProfileGearChange
             sd.targ_g = 3; sd.curr_g = 4;
             sd.shift_solenoid = sol_y4;
             sd.torque_cut_multiplier = 0.9;
-            sd.sip_threshold = SIP_4_3;
             break;
         case ProfileGearChange::THREE_TWO:
             sd.initial_spc_pwm = find_spc_pressure(spc_3_2, this->sensor_data);
@@ -138,7 +132,6 @@ ShiftData PressureManager::get_shift_data(SensorData* sensors, ProfileGearChange
             sd.targ_g = 2; sd.curr_g = 3;
             sd.shift_solenoid = sol_y5;
             sd.torque_cut_multiplier = 0.9;
-            sd.sip_threshold = SIP_3_2;
             break;
         case ProfileGearChange::TWO_ONE:
             sd.initial_spc_pwm = find_spc_pressure(spc_2_1, this->sensor_data);
@@ -146,7 +139,6 @@ ShiftData PressureManager::get_shift_data(SensorData* sensors, ProfileGearChange
             sd.targ_g = 1; sd.curr_g = 2;
             sd.shift_solenoid = sol_y3;
             sd.torque_cut_multiplier = 0.9;
-            sd.sip_threshold = SIP_2_1;
             break;
     }
     sd.spc_dec_speed = (chars.shift_speed * find_temp_ramp_speed_multiplier(sensors->atf_temp));

--- a/src/pressure_manager.h
+++ b/src/pressure_manager.h
@@ -94,21 +94,6 @@ const pressure_map mpc_5_4 = {500, 480, 460, 440, 420, 400, 360, 360, 350, 340, 
 
 #define SHIFT_IN_PROGRESS_THRESH 25 // 25%
 
-const int SIP_1_2 = ((RAT_1*(100+SHIFT_IN_PROGRESS_THRESH))+(RAT_2*(100-SHIFT_IN_PROGRESS_THRESH)))/2;
-const int SIP_2_3 = ((RAT_2*(100+SHIFT_IN_PROGRESS_THRESH))+(RAT_3*(100-SHIFT_IN_PROGRESS_THRESH)))/2;
-const int SIP_3_4 = ((RAT_3*(100+SHIFT_IN_PROGRESS_THRESH))+(RAT_4*(100-SHIFT_IN_PROGRESS_THRESH)))/2;
-const int SIP_4_5 = ((RAT_4*(100+SHIFT_IN_PROGRESS_THRESH))+(RAT_5*(100-SHIFT_IN_PROGRESS_THRESH)))/2;
-
-const int SIP_2_1 = ((RAT_1*(100-SHIFT_IN_PROGRESS_THRESH))+(RAT_2*(100+SHIFT_IN_PROGRESS_THRESH)))/2;
-const int SIP_3_2 = ((RAT_2*(100-SHIFT_IN_PROGRESS_THRESH))+(RAT_3*(100+SHIFT_IN_PROGRESS_THRESH)))/2;
-const int SIP_4_3 = ((RAT_3*(100-SHIFT_IN_PROGRESS_THRESH))+(RAT_4*(100+SHIFT_IN_PROGRESS_THRESH)))/2;
-const int SIP_5_4 = ((RAT_4*(100-SHIFT_IN_PROGRESS_THRESH))+(RAT_5*(100+SHIFT_IN_PROGRESS_THRESH)))/2;
-
-const float TC_1_2 = (RAT_2/RAT_1);
-const float TC_2_3 = (RAT_3/RAT_2);
-const float TC_3_4 = (RAT_4/RAT_3);
-const float TC_4_5 = (RAT_5/RAT_4);
-
 /*
 const float pressure_temp_normalizer[17] = {
     0.7, 0.72, 0.75, 0.78, 0.84, // -40-0C (0-40)
@@ -175,7 +160,7 @@ public:
         }
     }
 
-    uint16_t find_working_mpc_pressure(GearboxGear curr_g, SensorData* sensors);
+    uint16_t find_working_mpc_pressure(GearboxGear curr_g, SensorData* sensors, int max_rated_torque);
 
     float get_tcc_temp_multiplier(int atf_temp);
 private:

--- a/src/pressure_manager.h
+++ b/src/pressure_manager.h
@@ -68,16 +68,16 @@ const pressure_map spc_3_4 = {490, 480, 470, 450, 430, 410, 400, 390, 380, 370, 
 const pressure_map mpc_3_4 = {490, 480, 470, 450, 430, 410, 400, 390, 380, 370, 360};
 
 // 4 -> 5 upshift
-const pressure_map spc_4_5 = {510, 500, 490, 480, 470, 460, 450, 440, 430, 420, 400};
-const pressure_map mpc_4_5 = {510, 500, 490, 480, 470, 460, 450, 440, 430, 420, 400};
+const pressure_map spc_4_5 = {500, 480, 460, 440, 420, 400, 380, 360, 340, 320, 300};
+const pressure_map mpc_4_5 = {500, 480, 460, 440, 420, 400, 380, 360, 340, 320, 300};
 
 // 2 -> 1 downshift
 const pressure_map spc_2_1 = {500, 490, 480, 470, 460, 450, 440, 430, 420, 410, 400};
 const pressure_map mpc_2_1 = {500, 490, 480, 470, 460, 450, 440, 430, 420, 410, 400};
 
 // 3 -> 2 downshift
-const pressure_map spc_3_2 = {500, 480, 460, 440, 420, 400, 380, 360, 340, 330, 320};
-const pressure_map mpc_3_2 = {500, 480, 460, 440, 420, 400, 380, 360, 340, 330, 320};
+const pressure_map spc_3_2 = {480, 470, 460, 450, 440, 430, 420, 410, 400, 380, 360};
+const pressure_map mpc_3_2 = {480, 470, 460, 450, 440, 430, 420, 410, 400, 380, 360};
 
 // 4 -> 3 downshift
 const pressure_map spc_4_3 = {480, 470, 460, 450, 440, 430, 420, 410, 400, 390, 380};
@@ -109,11 +109,13 @@ const float TC_2_3 = (RAT_3/RAT_2);
 const float TC_3_4 = (RAT_4/RAT_3);
 const float TC_4_5 = (RAT_5/RAT_4);
 
+/*
 const float pressure_temp_normalizer[17] = {
     0.7, 0.72, 0.75, 0.78, 0.84, // -40-0C (0-40)
     0.89, 0.93, 0.96, 0.98, 0.99, // 10-50C (50-90)
     1, 1, 1, 1, 1, 1, 1.01 //60C-120C (100-160) - NOTE. Keep 60-110C as '1.0' to allow adaptation!
 };
+*/
 
 const float ramp_speed_temp_normalizer[17] = {
     1.3, 1.28, 1.25, 1.22, 1.16, // -40-0C (0-40)
@@ -124,7 +126,7 @@ const float ramp_speed_temp_normalizer[17] = {
 // 0, 1k, 2k, 3k, 4k, 5k, 6k, 7k, 8k RPM
 const float rpm_normalizer[9] = {1.03, 1.02, 1.00, 0.97, 0.93, 0.90, 0.85, 0.8, 0.75};
 
-const float rpm_working_normalizer[9] = {0.9, 0.95, 1.00, 1.05, 1.1, 1.15, 1.2, 1.25, 1.3};
+const float rpm_working_normalizer[9] = {0.9, 0.95, 1.00, 1.1, 1.2, 1.25, 1.3, 1.35, 1.4};
 // 0 -> 100% rated torque
 const pressure_map working_norm_pressure = {400, 380, 360, 340, 320, 300, 280, 260, 240, 220, 200};
 // RPM vs MPC pressure when driving (0-8000RPM)

--- a/src/pressure_manager.h
+++ b/src/pressure_manager.h
@@ -5,89 +5,84 @@
 #include "profiles.h"
 #include "adaptation/adapt_map.h"
 #include <gearbox_config.h>
-
-// Default maps (Needs modifying!)
+#include "nvs/eeprom_config.h"
 
 /*
-    Large NAG W5A580 gearbox pressure maps
+    Large NAG W5A580 gearbox pressure maps (Defaults)
 */
 
-#ifdef LARGE_NAG
-
 // 1 -> 2 upshift
-const pressure_map spc_1_2 = {520, 500, 480, 460, 440, 420, 400, 390, 380, 370, 350};
-const pressure_map mpc_1_2 = {520, 500, 480, 460, 440, 420, 400, 390, 380, 370, 350};
+const pressure_map spc_1_2_large = {520, 500, 480, 460, 440, 420, 400, 390, 380, 370, 350};
+const pressure_map mpc_1_2_large = {520, 500, 480, 460, 440, 420, 400, 390, 380, 370, 350};
 
 // 2 -> 3 upshift
-const pressure_map spc_2_3 = {450, 430, 420, 400, 380, 360, 340, 320, 300, 280, 260};
-const pressure_map mpc_2_3 = {450, 430, 420, 400, 380, 360, 340, 320, 300, 280, 260};
+const pressure_map spc_2_3_large = {450, 430, 420, 400, 380, 360, 340, 320, 300, 280, 260};
+const pressure_map mpc_2_3_large = {450, 430, 420, 400, 380, 360, 340, 320, 300, 280, 260};
 
 
 // 3 -> 4 upshift
-const pressure_map spc_3_4 = {380, 370, 360, 350, 340, 330, 320, 300, 280, 260, 240};
-const pressure_map mpc_3_4 = {380, 370, 360, 350, 340, 330, 320, 300, 280, 260, 240};
+const pressure_map spc_3_4_large = {380, 370, 360, 350, 340, 330, 320, 300, 280, 260, 240};
+const pressure_map mpc_3_4_large = {380, 370, 360, 350, 340, 330, 320, 300, 280, 260, 240};
 
  
 // 4 -> 5 upshift
-const pressure_map spc_4_5 = {450, 440, 430, 420, 410, 400, 390, 380, 360, 340, 300};
-const pressure_map mpc_4_5 = {450, 440, 430, 420, 410, 400, 390, 380, 360, 340, 300};
+const pressure_map spc_4_5_large = {450, 440, 430, 420, 410, 400, 390, 380, 360, 340, 300};
+const pressure_map mpc_4_5_large = {450, 440, 430, 420, 410, 400, 390, 380, 360, 340, 300};
 
 
 // 2 -> 1 downshift
-const pressure_map spc_2_1 = {530, 510, 500, 490, 480, 475, 470, 460, 450, 420, 400};
-const pressure_map mpc_2_1 = {530, 510, 500, 490, 480, 475, 470, 460, 450, 420, 400};
+const pressure_map spc_2_1_large = {530, 510, 500, 490, 480, 475, 470, 460, 450, 420, 400};
+const pressure_map mpc_2_1_large = {530, 510, 500, 490, 480, 475, 470, 460, 450, 420, 400};
 
 // 3 -> 2 downshift
-const pressure_map spc_3_2 = {400, 390, 380, 360, 350, 340, 330, 320, 310, 300, 300};
-const pressure_map mpc_3_2 = {400, 390, 380, 360, 350, 340, 330, 320, 310, 300, 300};
+const pressure_map spc_3_2_large = {400, 390, 380, 360, 350, 340, 330, 320, 310, 300, 300};
+const pressure_map mpc_3_2_large = {400, 390, 380, 360, 350, 340, 330, 320, 310, 300, 300};
 
 // 4 -> 3 downshift
-const pressure_map spc_4_3 = {420, 415, 410, 400, 390, 380, 370, 350, 330, 310, 290};
-const pressure_map mpc_4_3 = {420, 415, 410, 400, 390, 380, 370, 350, 330, 310, 290};
+const pressure_map spc_4_3_large = {420, 415, 410, 400, 390, 380, 370, 350, 330, 310, 290};
+const pressure_map mpc_4_3_large = {420, 415, 410, 400, 390, 380, 370, 350, 330, 310, 290};
 
 // 5 -> 4 downshift
-const pressure_map spc_5_4 = {430, 420, 395, 385, 385, 370, 360, 360, 350, 340, 325};
-const pressure_map mpc_5_4 = {430, 420, 395, 385, 385, 370, 360, 360, 350, 340, 325};
+const pressure_map spc_5_4_large = {430, 420, 395, 385, 385, 370, 360, 360, 350, 340, 325};
+const pressure_map mpc_5_4_large = {430, 420, 395, 385, 385, 370, 360, 360, 350, 340, 325};
 
-#else
 
 /*
-    Small NAG W5A330 gearbox pressure maps
+    Small NAG W5A330 gearbox pressure maps (Defaults)
 */
 
 // 1 -> 2 upshift
-const pressure_map spc_1_2 = {550, 540, 530, 520, 510, 500, 490, 480, 470, 460, 450};
-const pressure_map mpc_1_2 = {550, 540, 530, 520, 510, 500, 490, 480, 470, 460, 450};
+const pressure_map spc_1_2_small = {550, 540, 530, 520, 510, 500, 490, 480, 470, 460, 450};
+const pressure_map mpc_1_2_small = {550, 540, 530, 520, 510, 500, 490, 480, 470, 460, 450};
 
 // 2 -> 3 upshift
-const pressure_map spc_2_3 = {490, 480, 470, 460, 450, 445, 440, 430, 420, 410, 400};
-const pressure_map mpc_2_3 = {490, 480, 470, 460, 450, 445, 440, 430, 420, 410, 400};
+const pressure_map spc_2_3_small = {490, 480, 470, 460, 450, 445, 440, 430, 420, 410, 400};
+const pressure_map mpc_2_3_small = {490, 480, 470, 460, 450, 445, 440, 430, 420, 410, 400};
 
 // 3 -> 4 upshift
-const pressure_map spc_3_4 = {490, 480, 470, 450, 430, 410, 400, 390, 380, 370, 360};
-const pressure_map mpc_3_4 = {490, 480, 470, 450, 430, 410, 400, 390, 380, 370, 360};
+const pressure_map spc_3_4_small = {490, 480, 470, 450, 430, 410, 400, 390, 380, 370, 360};
+const pressure_map mpc_3_4_small = {490, 480, 470, 450, 430, 410, 400, 390, 380, 370, 360};
 
 // 4 -> 5 upshift
-const pressure_map spc_4_5 = {500, 480, 460, 440, 420, 400, 380, 360, 340, 320, 300};
-const pressure_map mpc_4_5 = {500, 480, 460, 440, 420, 400, 380, 360, 340, 320, 300};
+const pressure_map spc_4_5_small = {500, 480, 460, 440, 420, 400, 380, 360, 340, 320, 300};
+const pressure_map mpc_4_5_small = {500, 480, 460, 440, 420, 400, 380, 360, 340, 320, 300};
 
 // 2 -> 1 downshift
-const pressure_map spc_2_1 = {500, 490, 480, 470, 460, 450, 440, 430, 420, 410, 400};
-const pressure_map mpc_2_1 = {500, 490, 480, 470, 460, 450, 440, 430, 420, 410, 400};
+const pressure_map spc_2_1_small = {500, 490, 480, 470, 460, 450, 440, 430, 420, 410, 400};
+const pressure_map mpc_2_1_small = {500, 490, 480, 470, 460, 450, 440, 430, 420, 410, 400};
 
 // 3 -> 2 downshift
-const pressure_map spc_3_2 = {480, 470, 460, 450, 440, 430, 420, 410, 400, 380, 360};
-const pressure_map mpc_3_2 = {480, 470, 460, 450, 440, 430, 420, 410, 400, 380, 360};
+const pressure_map spc_3_2_small = {480, 470, 460, 450, 440, 430, 420, 410, 400, 380, 360};
+const pressure_map mpc_3_2_small = {480, 470, 460, 450, 440, 430, 420, 410, 400, 380, 360};
 
 // 4 -> 3 downshift
-const pressure_map spc_4_3 = {480, 470, 460, 450, 440, 430, 420, 410, 400, 390, 380};
-const pressure_map mpc_4_3 = {480, 470, 460, 450, 440, 430, 420, 410, 400, 390, 380};
+const pressure_map spc_4_3_small = {480, 470, 460, 450, 440, 430, 420, 410, 400, 390, 380};
+const pressure_map mpc_4_3_small = {480, 470, 460, 450, 440, 430, 420, 410, 400, 390, 380};
 
 // 5 -> 4 downshift
-const pressure_map spc_5_4 = {500, 480, 460, 440, 420, 400, 360, 360, 350, 340, 325};
-const pressure_map mpc_5_4 = {500, 480, 460, 440, 420, 400, 360, 360, 350, 340, 325};
+const pressure_map spc_5_4_small = {500, 480, 460, 440, 420, 400, 360, 360, 350, 340, 325};
+const pressure_map mpc_5_4_small = {500, 480, 460, 440, 420, 400, 360, 360, 350, 340, 325};
 
-#endif
 
 // These values are autogenerated by the compiler. Please do NOT modify!
 // The gearbox uses these values to work out when to stop torque cutting and monitoring shift progress
@@ -109,9 +104,9 @@ const float ramp_speed_temp_normalizer[17] = {
 };
 
 // 0, 1k, 2k, 3k, 4k, 5k, 6k, 7k, 8k RPM
-const float rpm_normalizer[9] = {1.03, 1.02, 1.00, 0.97, 0.93, 0.90, 0.85, 0.8, 0.75};
+const rpm_modifier_map rpm_normalizer = {1.03, 1.02, 1.00, 0.97, 0.93, 0.90, 0.85, 0.8, 0.75};
 
-const float rpm_working_normalizer[9] = {0.9, 0.95, 1.00, 1.1, 1.2, 1.25, 1.3, 1.35, 1.4};
+const rpm_modifier_map rpm_working_normalizer = {0.9, 0.95, 1.00, 1.1, 1.2, 1.25, 1.3, 1.35, 1.4};
 // 0 -> 100% rated torque
 const pressure_map working_norm_pressure = {400, 380, 360, 340, 320, 300, 280, 260, 240, 220, 200};
 // RPM vs MPC pressure when driving (0-8000RPM)
@@ -122,10 +117,7 @@ typedef void (*P_RAMP_FUNC)(float, float);
 class PressureManager {
 
 public:
-    PressureManager(SensorData* sensor_ptr) {
-        this->sensor_data = sensor_ptr;
-        this->adapt_map = new AdaptationMap();
-    }
+    PressureManager(SensorData* sensor_ptr);
 
     /**
      * @brief In the event a gear change is in progress, and the gearbox needs to abort the shift
@@ -167,6 +159,7 @@ private:
     bool abort = false;
     SensorData* sensor_data;
     AdaptationMap* adapt_map;
+    PressureMgrData map_data;
 };
 
 #endif

--- a/src/profiles.cpp
+++ b/src/profiles.cpp
@@ -105,7 +105,7 @@ bool ComfortProfile::should_downshift(GearboxGear current_gear, SensorData* sens
 
 TccLockupBounds ComfortProfile::get_tcc_lockup_bounds(SensorData* sensors, GearboxGear curr_gear) {
     return TccLockupBounds {
-        .max_slip_rpm = (int)MAX(100, sensors->static_torque*1.5),
+        .max_slip_rpm = (int)MAX(100, sensors->static_torque*1.2),
         .min_slip_rpm = (int)MAX(50, sensors->static_torque)
     };
 }
@@ -160,8 +160,8 @@ bool WinterProfile::should_downshift(GearboxGear current_gear, SensorData* senso
 // Minimum lockup
 TccLockupBounds WinterProfile::get_tcc_lockup_bounds(SensorData* sensors, GearboxGear curr_gear) {
     return TccLockupBounds {
-        .max_slip_rpm = (int)MAX(100, sensors->static_torque*2),
-        .min_slip_rpm = (int)MAX(50, sensors->static_torque*1.5)
+        .max_slip_rpm = (int)MAX(100, sensors->static_torque*1.5),
+        .min_slip_rpm = (int)MAX(50, sensors->static_torque)
     };
 }
 
@@ -270,14 +270,13 @@ bool StandardProfile::should_downshift(GearboxGear current_gear, SensorData* sen
     if (current_gear == GearboxGear::First) { return false; }
     float pedal_perc = ((float)sensors->pedal_pos*100)/250.0;
     float rpm_percent = (float)(sensors->input_rpm-1000)*100.0/(float)(4500-1000);
-    unsigned long t =  esp_timer_get_time()/1000;
     if (current_gear == GearboxGear::Second && (sensors->input_rpm > 300 || sensors->engine_rpm > 800)) {
         return false;
     }
     if (sensors->input_rpm < 900) {
         return true;
     }
-    else if (sensors->input_rpm < 2000 && sensors->engine_rpm < 2500 && pedal_perc >= rpm_percent*4 && t-sensors->last_shift_time > 2000) {
+    else if (sensors->input_rpm < 2200 && sensors->engine_rpm < 2500 && pedal_perc >= rpm_percent*4) {
         if (current_gear == GearboxGear::Second) {
             return false;
         }
@@ -290,8 +289,8 @@ bool StandardProfile::should_downshift(GearboxGear current_gear, SensorData* sen
 
 TccLockupBounds StandardProfile::get_tcc_lockup_bounds(SensorData* sensors, GearboxGear curr_gear) {
     return TccLockupBounds {
-        .max_slip_rpm = (int)MAX(50, sensors->static_torque*1.2),
-        .min_slip_rpm = (int)MAX(10, sensors->static_torque/2)
+        .max_slip_rpm = (int)MAX(50, sensors->static_torque),
+        .min_slip_rpm = (int)MAX(1, sensors->static_torque/2)
     };
 }
 
@@ -346,7 +345,7 @@ bool ManualProfile::should_downshift(GearboxGear current_gear, SensorData* senso
 
 TccLockupBounds ManualProfile::get_tcc_lockup_bounds(SensorData* sensors, GearboxGear curr_gear) {
     return TccLockupBounds {
-        .max_slip_rpm = (int)MAX(30, sensors->static_torque),
+        .max_slip_rpm = (int)MAX(30, sensors->static_torque/2),
         .min_slip_rpm = (int)MAX(0, sensors->static_torque/4)
     };
 }

--- a/src/profiles.cpp
+++ b/src/profiles.cpp
@@ -2,6 +2,7 @@
 #include <gearbox_config.h>
 #include "adv_opts.h"
 #include "tcm_maths.h"
+#include "gearbox.h"
 
 GearboxDisplayGear AgilityProfile::get_display_gear(GearboxGear target, GearboxGear actual) {
    switch (target) {
@@ -30,9 +31,9 @@ GearboxDisplayGear AgilityProfile::get_display_gear(GearboxGear target, GearboxG
 
 
 ShiftCharacteristics AgilityProfile::get_shift_characteristics(ProfileGearChange requested, SensorData* sensors) {
-    float dp = ((float)(sensors->pedal_pos)/250.0f) *2;
-    if (dp > 1) {
-        dp = 1;
+    float dp = ((float)(sensors->pedal_pos*100)/250.0f);
+    if (dp > 10) {
+        dp = 10;
     }
     if (dp == 0) {
         dp = 1;
@@ -113,7 +114,7 @@ TccLockupBounds ComfortProfile::get_tcc_lockup_bounds(SensorData* sensors, Gearb
 ShiftCharacteristics WinterProfile::get_shift_characteristics(ProfileGearChange requested, SensorData* sensors) {
     return ShiftCharacteristics {
         .target_d_rpm = 20,
-        .shift_speed = 1.0,
+        .shift_speed = 3.0,
     };
 }
 
@@ -239,7 +240,7 @@ GearboxDisplayGear StandardProfile::get_display_gear(GearboxGear target, Gearbox
 bool StandardProfile::should_upshift(GearboxGear current_gear, SensorData* sensors) {
     if (current_gear == GearboxGear::Fifth) { return false; }
     int curr_rpm = sensors->input_rpm;
-    if (curr_rpm > 4500) { // Protect da engine
+    if (curr_rpm >= Gearbox::redline_rpm) {
         return true;
     }
     if (sensors->pedal_pos == 0 || sensors->is_braking) { // Don't upshift if not pedal or braking
@@ -269,14 +270,14 @@ bool StandardProfile::should_upshift(GearboxGear current_gear, SensorData* senso
 bool StandardProfile::should_downshift(GearboxGear current_gear, SensorData* sensors) {
     if (current_gear == GearboxGear::First) { return false; }
     float pedal_perc = ((float)sensors->pedal_pos*100)/250.0;
-    float rpm_percent = (float)(sensors->input_rpm-1000)*100.0/(float)(4500-1000);
+    float rpm_percent = (float)(sensors->input_rpm-MIN_WORKING_RPM)*100.0/(float)(Gearbox::redline_rpm-MIN_WORKING_RPM);
     if (current_gear == GearboxGear::Second && (sensors->input_rpm > 300 || sensors->engine_rpm > 800)) {
         return false;
     }
-    if (sensors->input_rpm < 900) {
+    if (sensors->input_rpm < MIN_WORKING_RPM && sensors->engine_rpm < MIN_WORKING_RPM) {
         return true;
     }
-    else if (sensors->input_rpm < 2200 && sensors->engine_rpm < 2500 && pedal_perc >= rpm_percent*4) {
+    else if (sensors->input_rpm < Gearbox::redline_rpm/2 && sensors->engine_rpm < Gearbox::redline_rpm/2 && pedal_perc >= rpm_percent*4) {
         if (current_gear == GearboxGear::Second) {
             return false;
         }
@@ -297,7 +298,7 @@ TccLockupBounds StandardProfile::get_tcc_lockup_bounds(SensorData* sensors, Gear
 ShiftCharacteristics ManualProfile::get_shift_characteristics(ProfileGearChange requested, SensorData* sensors) {
     return ShiftCharacteristics {
         .target_d_rpm = 70,
-        .shift_speed = 10.0,
+        .shift_speed = 20.0,
     };
 }
 
@@ -334,7 +335,7 @@ bool ManualProfile::should_downshift(GearboxGear current_gear, SensorData* senso
 #ifdef MANUAL_AUTO_DOWNSHIFT
     if (current_gear == GearboxGear::First) {
         return false;
-    } else if (sensors->input_rpm < 300 && sensors->engine_rpm < 800 && sensors->pedal_pos == 0) {
+    } else if (sensors->input_rpm < 300 && sensors->engine_rpm < MIN_WORKING_RPM && sensors->pedal_pos == 0) {
         return true;
     }
     return false;

--- a/src/profiles.h
+++ b/src/profiles.h
@@ -8,6 +8,12 @@
 
 #define MAX_PROFILES 4
 
+#define PROFILE_ID_STANDARD 0
+#define PROFILE_ID_COMFORT 1
+#define PROFILE_ID_WINTER 2
+#define PROFILE_ID_AGILITY 3
+#define PROFILE_ID_MANUAL 4
+
 /**
  * A profile is designed to read the current conditions of the gearbox and request the gearbox to do something
  */

--- a/src/solenoids/solenoids.cpp
+++ b/src/solenoids/solenoids.cpp
@@ -154,6 +154,8 @@ Solenoid *sol_mpc = nullptr;
 Solenoid *sol_spc = nullptr;
 Solenoid *sol_tcc = nullptr;
 
+Solenoid *pressure_pwm_solenoids[2] = { sol_spc, sol_mpc };
+
 #define BYTES_PER_SAMPLE 2
 #define NUM_SAMPLES 1024
 
@@ -297,5 +299,6 @@ bool init_all_solenoids()
         return false;
     }
 
+    
     return true;
 }

--- a/src/solenoids/solenoids.h
+++ b/src/solenoids/solenoids.h
@@ -100,6 +100,13 @@ public:
     // Internal functions - Don't touch, handled by I2S thread!
     void __set_current_internal(uint16_t c);
     void __set_vref(uint16_t ref);
+
+
+    // IMPORTANT - ONLY CALL THESE 2 FUNCTIONS FROM SPC AND MPC solenoid!
+    void set_fade_from_current_pwm_with_voltage(uint16_t targ_pwm, uint16_t time_ms);
+    void set_fade_with_voltage(uint16_t start_pwm, uint16_t targ_pwm, uint16_t time_ms);
+
+    // -- These functions are only accessed by sw_fader class! -- //
 private:
     uint32_t default_freq;
     bool ready;
@@ -128,5 +135,12 @@ extern Solenoid *sol_y5;
 extern Solenoid *sol_mpc;
 extern Solenoid *sol_spc;
 extern Solenoid *sol_tcc;
+
+enum PwmSolenoid {
+    PWM_SPC = 0,
+    PWM_MPC = 1
+};
+
+extern Solenoid* pressure_pwm_solenoids[2];
 
 #endif // __SOLENOID_H_

--- a/src/solenoids/sw_fader.cpp
+++ b/src/solenoids/sw_fader.cpp
@@ -1,0 +1,12 @@
+#include "sw_fader.h"
+#include "solenoids.h"
+
+void fader_loop() {
+    Solenoid* pwm_solenoids[2] = { sol_mpc, sol_spc };
+    while(1) {
+
+        
+
+        vTaskDelay(5);
+    }
+}

--- a/src/solenoids/sw_fader.h
+++ b/src/solenoids/sw_fader.h
@@ -1,0 +1,8 @@
+
+#ifndef __SW_FADER_H__
+#define __SW_FADER_H__
+
+[[noreturn]]
+void fader_loop();
+
+#endif


### PR DESCRIPTION
This removes the following configurations from firmware compilation process
and instead places them in EEPROM, which can be adjusted on the fly using the [config suite](https://github.com/rnd-ash/ultimate_nag52/tree/main/config_app)

* Box type (Small/Large NAG)
* Fourmatic (And transfer case ratios)
* Diff ratio
* Tyre size
* NEW - Startup profile on TCM boot
* Engine type (And redline RPM)