### PR TITLE
Bugfix update (21/08/23)

### DIFF
--- a/src/adaptation/shift_report.cpp
+++ b/src/adaptation/shift_report.cpp
@@ -24,7 +24,7 @@ bool load_shift_report_from_partition(ShiftReportNvsGroup* dest, uint32_t addr) 
     }
     uint16_t raw_crc = calc_shift_report_group_crc(dest);
     if (dest->crc != raw_crc) {
-        ESP_LOG_LEVEL(ESP_LOG_INFO, "SHIFT_REPORT", "Load from SPIFFS was invalid, resetting. CRC was %08X, wanted CRC: %08X", dest->crc, raw_crc);
+        //ESP_LOG_LEVEL(ESP_LOG_INFO, "SHIFT_REPORT", "Load from SPIFFS was invalid, resetting. CRC was %08X, wanted CRC: %08X", dest->crc, raw_crc);
         memset(dest, 0x00, sizeof(ShiftReportNvsGroup)); // Blank it if invalid!
         return false;
     }

--- a/src/canbus/can_egs51.cpp
+++ b/src/canbus/can_egs51.cpp
@@ -131,7 +131,7 @@ uint8_t Egs51Can::get_pedal_value(uint64_t now, uint64_t expire_time_ms) { // TO
 int Egs51Can::get_static_engine_torque(uint64_t now, uint64_t expire_time_ms) {
     MS_310_EGS51 ms310;
     if (this->ms51.get_MS_310(now, expire_time_ms, &ms310)) {
-        return (int)ms310.IND_TORQUE*3 - (int)(ms310.DRG_TORQUE*3);
+        return ms310.IND_TORQUE*3;
     } else {
         return INT_MAX;
     }
@@ -146,7 +146,7 @@ int Egs51Can::get_driver_engine_torque(uint64_t now, uint64_t expire_time_ms) {
 int Egs51Can::get_maximum_engine_torque(uint64_t now, uint64_t expire_time_ms) {
     MS_310_EGS51 ms310;
     if (this->ms51.get_MS_310(now, expire_time_ms, &ms310)) {
-        return (float)(ms310.MAX_TORQUE*3) * ((float)(ms310.MAX_TRQ_FACTOR * 0.0078));
+        return ms310.MAX_TORQUE*3;
     } else {
         return INT_MAX;
     }


### PR DESCRIPTION
* Removes useless warning about SPIFFS cache invalid when loading shift report data - The shift report data is currently not used so we can safely ignore this
* *Fixed very wonky EGS51 torque requests* - The torque getter for motor static torque was incorrect. Revert to April firmware behaviour