### PR TITLE
Minor corrections to comply with MISRA C-rules & inrush solenoid frequency change

### DIFF
--- a/src/solenoids/inrush_solenoid.cpp
+++ b/src/solenoids/inrush_solenoid.cpp
@@ -10,7 +10,7 @@ const uint16_t INRUSH_TIME_US = 15000;
 const uint16_t INRUSH_PWM = 4096;
 const uint16_t HOLD_PWM = 1300;
 
-const uint32_t TOTAL_PERIOD_TIME_US = 100000; // Timer runs at 10Khz, Hydralic PWM is 100Hz, so 10_000_000/100
+const uint32_t TOTAL_PERIOD_TIME_US = 100000; // Timer runs at 10MHz, Hydralic PWM is 100Hz, so 10_000_000/100
 
 
 static bool IRAM_ATTR inrush_solenoid_timer_isr(gptimer_handle_t timer, const gptimer_alarm_event_data_t *edata, void *user_data) {
@@ -69,7 +69,7 @@ InrushControlSolenoid::InrushControlSolenoid(const char *name, ledc_timer_t ledc
     const gptimer_config_t timer_config = {
         .clk_src = GPTIMER_CLK_SRC_DEFAULT,
         .direction = GPTIMER_COUNT_UP,
-        .resolution_hz = (10u * 1000u), // 10Khz
+        .resolution_hz = (10u * 1000u * 1000u), // 10MHz
         .flags = {
             .intr_shared = 0
         }

--- a/src/solenoids/inrush_solenoid.cpp
+++ b/src/solenoids/inrush_solenoid.cpp
@@ -14,7 +14,7 @@ const uint32_t TOTAL_PERIOD_TIME_US = 100000; // Timer runs at 10Khz, Hydralic P
 
 
 static bool IRAM_ATTR inrush_solenoid_timer_isr(gptimer_handle_t timer, const gptimer_alarm_event_data_t *edata, void *user_data) {
-    InrushControlSolenoid* solenoid = (InrushControlSolenoid*)user_data;
+    InrushControlSolenoid* solenoid = reinterpret_cast<InrushControlSolenoid*>(user_data);
     uint32_t next_alarm_in = solenoid->on_timer_interrupt();
     gptimer_alarm_config_t alarm_config = {
         .alarm_count = edata->alarm_value + next_alarm_in,
@@ -69,7 +69,7 @@ InrushControlSolenoid::InrushControlSolenoid(const char *name, ledc_timer_t ledc
     const gptimer_config_t timer_config = {
         .clk_src = GPTIMER_CLK_SRC_DEFAULT,
         .direction = GPTIMER_COUNT_UP,
-        .resolution_hz = (1 * 1000 * 1000 * 10), // 10Khz
+        .resolution_hz = (10u * 1000u), // 10Khz
         .flags = {
             .intr_shared = 0
         }
@@ -91,7 +91,7 @@ InrushControlSolenoid::InrushControlSolenoid(const char *name, ledc_timer_t ledc
             };
             this->ready = gptimer_set_alarm_action(this->timer, &alarm_config);
             if (ESP_OK == ready) {
-                this->ready = gptimer_register_event_callbacks(this->timer, &cbs, (void*)this);
+                this->ready = gptimer_register_event_callbacks(this->timer, &cbs, reinterpret_cast<void*>(this));
                 if (ESP_OK == ready) {
                     this->ready = gptimer_enable(this->timer);
                     if (ESP_OK == ready) {

--- a/src/solenoids/on_off_solenoid.cpp
+++ b/src/solenoids/on_off_solenoid.cpp
@@ -39,10 +39,11 @@ void OnOffSolenoid::off() {
     this->holding = false;
 }
 
-bool OnOffSolenoid::is_on() {
-    return this->state;
-}
+/* unused */
+// bool OnOffSolenoid::is_on() {
+//     return this->state;
+// }
 
-bool OnOffSolenoid::is_max_on() {
-    return this->state && !this->holding;
-}
+// bool OnOffSolenoid::is_max_on() {
+//     return this->state && !this->holding;
+// }

--- a/src/solenoids/on_off_solenoid.h
+++ b/src/solenoids/on_off_solenoid.h
@@ -1,5 +1,5 @@
-#ifndef __ON_OFF_SOLENOID_H_
-#define __ON_OFF_SOLENOID_H_
+#ifndef ON_OFF_SOLENOID_H
+#define ON_OFF_SOLENOID_H
 
 #include "pwm_solenoid.h"
 #include "driver/gptimer.h"
@@ -8,10 +8,11 @@ class OnOffSolenoid : public PwmSolenoid {
 public:
     explicit OnOffSolenoid(const char *name, ledc_timer_t ledc_timer, gpio_num_t pwm_pin, ledc_channel_t channel, adc_channel_t read_channel, uint32_t on_time_ms, uint16_t hold_pwm, uint16_t phase_duration_ms);
     void __write_pwm(float vref_compensation, float temperature_factor);
-    void on();
-    void off();
-    bool is_on();
-    bool is_max_on();
+    void on(void);
+    void off(void);
+    /* unused */
+    // bool is_on(void);
+    // bool is_max_on(void);
 
 private:
     uint32_t on_time_ms = 0u;

--- a/src/solenoids/pwm_solenoid.cpp
+++ b/src/solenoids/pwm_solenoid.cpp
@@ -53,12 +53,12 @@ uint16_t PwmSolenoid::get_current() const {
     uint32_t raw = this->current_adc_reading;
     uint16_t ret = 0;
     if (0 != raw) {
-        adc_cali_raw_to_voltage(adc1_cal, raw, (int*)&ret);
+        adc_cali_raw_to_voltage(adc1_cal, raw, reinterpret_cast<int*>(&ret));
     }
     return ret * pcb_gpio_matrix->sensor_data.current_sense_multi;
 }
 
-uint16_t PwmSolenoid::get_pwm_raw()
+uint16_t PwmSolenoid::get_pwm_raw() const
 {
     return this->pwm_raw;
 }
@@ -103,13 +103,15 @@ esp_err_t PwmSolenoid::init_ok() const
     return this->ready;
 }
 
-uint16_t PwmSolenoid::get_ledc_pwm() {
-    return ledc_get_duty(LEDC_HIGH_SPEED_MODE, this->channel);
-}
+/* unused */
+// uint16_t PwmSolenoid::get_ledc_pwm() {
+//     return ledc_get_duty(LEDC_HIGH_SPEED_MODE, this->channel);
+// }
 
-uint16_t PwmSolenoid::get_pwm_phase_time() const {
-    return this->pwm_phase_period_ms;
-}
+/* unused */
+// uint16_t PwmSolenoid::get_pwm_phase_time() const {
+//     return this->pwm_phase_period_ms;
+// }
 
 
 esp_err_t SolenoidSetup::init_adc() {

--- a/src/solenoids/pwm_solenoid.h
+++ b/src/solenoids/pwm_solenoid.h
@@ -1,5 +1,5 @@
-#ifndef __PWM_SOLENOID_H_
-#define __PWM_SOLENOID_H_
+#ifndef PWM_SOLENOID_H
+#define PWM_SOLENOID_H
 
 #include <stdint.h>
 #include "driver/gpio.h"
@@ -14,12 +14,13 @@
 extern uint16_t voltage;
 extern uint16_t min_adc_v_reading;
 extern uint16_t min_adc_raw_reading;
-extern const ledc_timer_config_t SOLENOID_TIMER_CFG;
+/* unused */
+// extern const ledc_timer_config_t SOLENOID_TIMER_CFG;
 
-typedef struct {
+struct SolenoidTestReading{
     uint16_t avg_voltage;
     uint16_t avg_current;
-} __attribute__((packed)) SolenoidTestReading;
+} __attribute__((packed));
 
 class PwmSolenoid
 {
@@ -37,16 +38,15 @@ public:
     PwmSolenoid(const char *name, ledc_timer_t ledc_timer, gpio_num_t pwm_pin, ledc_channel_t channel, adc_channel_t read_channel, uint16_t phase_duration_ms);
 
 
-    const char* get_name(void) {
-        return this->name;
-    }
+    /* unused */
+    // const char* get_name(void) const;
 
     /**
      * @brief Returns the raw PWM that was requested by write_pwm_12_bit
      * 
      * @return The raw PWM duty that was requested
      */
-    uint16_t get_pwm_raw(void);
+    uint16_t get_pwm_raw(void) const;
 
     /**
      * @brief returns the actual PWM that is being written to the solenoid
@@ -58,7 +58,8 @@ public:
      */
     uint16_t get_pwm_compensated(void) const;
 
-    uint16_t get_ledc_pwm(void);
+    /* unused */
+    // uint16_t get_ledc_pwm(void);
 
     /**
      * @brief Gets the current consumed by the solenoid at the previous I2S sample
@@ -79,11 +80,12 @@ public:
      */
     esp_err_t init_ok(void) const;
 
+/* unused */
     /**
      * @brief Gets the time in milliseconds of a full PWM cycle
      * @return PWM phase duration
      */
-    uint16_t get_pwm_phase_time() const;
+    // uint16_t get_pwm_phase_time() const;
 
     // Internal functions - Don't touch, handled by I2S thread!
     void __set_adc_reading(uint16_t c);

--- a/src/solenoids/solenoids.cpp
+++ b/src/solenoids/solenoids.cpp
@@ -79,7 +79,8 @@ void read_solenoids_i2s(void*) {
         ret = adc_continuous_read(c_handle, adc_read_buf, I2S_DMA_BUF_LEN, &read_len, portMAX_DELAY);
         if (ESP_OK == ret) {
             for (int i = 0; i < read_len; i += SOC_ADC_DIGI_RESULT_BYTES) {
-                adc_digi_output_data_t *p = (adc_digi_output_data_t*)&adc_read_buf[i];
+                // adc_digi_output_data_t *p = (adc_digi_output_data_t*)&adc_read_buf[i];
+                adc_digi_output_data_t *p = reinterpret_cast<adc_digi_output_data_t*>(&adc_read_buf[i]);
                 uint8_t channel_idx = CHANNEL_ID_MAP[p->type1.channel];
                 if (channel_idx != 0xFF) {
                     if (p->type1.data > 100) { // > ~0.1V


### PR DESCRIPTION
Some minor corrections and one change of the inrush solenoid frequency from 10MHz to 10kHz, according to https://docs.espressif.com/projects/esp-idf/en/stable/esp32s3/api-reference/peripherals/gptimer.html.