### PR TITLE
Increase accuracy of the TFT Sensor

### DIFF
--- a/lib/core/tcu_maths.h
+++ b/lib/core/tcu_maths.h
@@ -140,21 +140,6 @@ float progress_between_targets(const float current, const float start, const flo
 /// @return the interpolated function value
 float interpolate(const float f_1, const float f_2, const int16_t x_1, const int16_t x_2, const float x);
 
-/// @brief Searches for a given value in values. idvalue_min and idvalue_max will be set to the indices between the value is found. This fuction assumes, that values has an ascending order.
-/// @param value The value to be searched for.
-/// @param values The array with the values to be searched within.
-/// @param size The size of values.
-/// @param idvalue_min The index for the value smaller than the value to be searched for.
-/// @param idvalue_max The index for the value greater than the value to be searched for.
-template <typename T> void search_value(const T value, const T *values, const uint16_t size, uint16_t *idvalue_min, uint16_t *idvalue_max);
-
-/// @brief Interpolates on a calibration table where you have an axis and a single value axis
-/// @param v - The value to look up the interpoaltion for
-/// @param len - The size of both X and Y, this function requires both to be the same len
-/// @param x - Pointer to X axis
-/// @param vals - Pointer to value axis
-template <typename T> float interpolate_linear_array(T v, const uint8_t len, const T* x, const T* vals);
-
 int linear_ramp_with_timer(int start, int end, int current_timer_val);
 
 #endif // TCU_MATHS_H

--- a/lib/core/tcu_maths_impl.h
+++ b/lib/core/tcu_maths_impl.h
@@ -3,6 +3,12 @@
 #ifndef TCU_MATHS_IMPL_H
 #define TCU_MATHS_IMPL_H
 
+/// @brief Searches for a given value in values. idvalue_min and idvalue_max will be set to the indices between the value is found. This fuction assumes, that values has an ascending order.
+/// @param value The value to be searched for.
+/// @param values The array with the values to be searched within.
+/// @param size The size of values.
+/// @param idvalue_min The index for the value smaller than the value to be searched for.
+/// @param idvalue_max The index for the value greater than the value to be searched for.
 template <typename T> void search_value(const T value, const T *values, const uint16_t size, uint16_t *idvalue_min, uint16_t *idvalue_max)
 {
 	// Set minimum index to the first element of the field.
@@ -43,6 +49,11 @@ template <typename T> void search_value(const T value, const T *values, const ui
     }
 }
 
+/// @brief Interpolates on a calibration table where you have an axis and a single value axis
+/// @param v - The value to look up the interpoaltion for
+/// @param len - The size of both X and Y, this function requires both to be the same len
+/// @param x - Pointer to X axis
+/// @param vals - Pointer to value axis
 template <typename T> float interpolate_linear_array(T v, const uint8_t len, const T* x, const T* vals) {
     uint16_t idx_min = 0;
     uint16_t idx_max = 0;

--- a/src/board_config.cpp
+++ b/src/board_config.cpp
@@ -31,7 +31,7 @@ BoardV11GpioMatrix::BoardV11GpioMatrix() {
     this->sensor_data = SensorFuncData {
         .adc_batt     = adc_channel_t::ADC_CHANNEL_8,
         .adc_atf      = adc_channel_t::ADC_CHANNEL_9,
-        .atf_calibration_curve = atf_temp_lookup_V11,
+        .atf_r2_resistance = 10000,
         .current_sense_multi = 2.0,
     };
 }
@@ -66,7 +66,7 @@ BoardV12GpioMatrix::BoardV12GpioMatrix() {
     this->sensor_data = SensorFuncData {
         .adc_batt     = adc_channel_t::ADC_CHANNEL_8,
         .adc_atf      = adc_channel_t::ADC_CHANNEL_7,
-        .atf_calibration_curve = atf_temp_lookup_V12,
+        .atf_r2_resistance = 2000,
         .current_sense_multi = 1.0,
     };
     ioexpander = new IOExpander(this->i2c_sda, this->i2c_scl);
@@ -115,7 +115,7 @@ BoardV13GpioMatrix::BoardV13GpioMatrix() {
     this->sensor_data = SensorFuncData {
         .adc_batt = adc_channel_t::ADC_CHANNEL_8,
         .adc_atf = adc_channel_t::ADC_CHANNEL_7,
-        .atf_calibration_curve = atf_temp_lookup_V12,
+        .atf_r2_resistance = 2000,
         .current_sense_multi = 1.0,
     };
     ioexpander = new IOExpander(this->i2c_sda, this->i2c_scl);

--- a/src/board_config.h
+++ b/src/board_config.h
@@ -6,45 +6,14 @@
 #include <esp_adc/adc_oneshot.h>
 #include "ioexpander.h"
 
-static const uint16_t NUM_TEMP_POINTS = 27u;
-
-struct temp_reading_t{
-    // Resistance in Ohms
-    uint16_t r_ohm; 
-    // ATF Temp in degrees C * 10
-    int temp; 
-};
+static const uint8_t NUM_TEMP_POINTS = 27u;
 
 // https://www.nxp.com/docs/en/data-sheet/KTY83_SER.pdf
-const static temp_reading_t TFT_RESISTANCE_TAB[NUM_TEMP_POINTS] = {
-// Resistance (Ohm), Temp(x10)
-    {500, -550},
-    {525, -500},
-    {577, -400},
-    {632, -300},
-    {691, -200},
-    {754, -100},
-    {820, 0},
-    {889, 100},
-    {962, 200},
-    {1000, 250},
-    {1039, 300},
-    {1118, 400},
-    {1202, 500},
-    {1288, 600},
-    {1379, 700},
-    {1472, 800},
-    {1569, 900},
-    {1670, 1000},
-    {1774, 1100},
-    {1882, 1200},
-    {1937, 1250},
-    {1993, 1300},
-    {2107, 1400},
-    {2225, 1500},
-    {2346, 1600},
-    {2471, 1700},
-    {2535, 1750},
+const static int16_t TFT_RESISTANCE_TAB[2][NUM_TEMP_POINTS] = {
+    // Resistance (Ohm)
+    { 500,  525,  577,  632,  691,  754, 820,  889,  962, 1000, 1039, 1118, 1202, 1288, 1379, 1472, 1569, 1670, 1774, 1882, 1937, 1993, 2107, 2225, 2346, 2471, 2535},
+    // Temperature
+    {-550, -500, -400, -300, -200, -100,   0,  100,  200,  250,  300,  400,  500,  600,  700,  800,  900, 1000, 1100, 1200, 1250, 1300, 1400, 1500, 1600, 1700, 1750}
 };
 
 struct SensorFuncData {

--- a/src/board_config.h
+++ b/src/board_config.h
@@ -6,77 +6,45 @@
 #include <esp_adc/adc_oneshot.h>
 #include "ioexpander.h"
 
-static const uint16_t NUM_TEMP_POINTS = 25u;
+static const uint16_t NUM_TEMP_POINTS = 27u;
 
 struct temp_reading_t{
-    // Voltage in mV
-    uint16_t v; 
+    // Resistance in Ohms
+    uint16_t r_ohm; 
     // ATF Temp in degrees C * 10
     int temp; 
 };
 
 // https://www.nxp.com/docs/en/data-sheet/KTY83_SER.pdf
-const static temp_reading_t atf_temp_lookup_V12[NUM_TEMP_POINTS] = {
-//    mV, Temp(x10)
-// mV Values are calibrated on 3.45V rail
-// as that is how much the ATF sensor power gets
-    {686, -500},
-    {738, -400},
-    {792, -300},
-    {847, -200},
-    {903, -100},
-    {959,  0},
-    {1015, 100},
-    {1071, 200},
-    {1100, 250},
-    {1128, 300},
-    {1183, 400},
-    {1238, 500},
-    {1292, 600},
-    {1346, 700},
-    {1399, 800},
-    {1450, 900},
-    {1501, 1000},
-    {1551, 1100},
-    {1599, 1200},
-    {1623, 1250},
-    {1647, 1300},
-    {1692, 1400},
-    {1737, 1500},
-    {1781, 1600},
-    {1823, 1700},
-};
-
-// https://www.nxp.com/docs/en/data-sheet/KTY83_SER.pdf
-const static temp_reading_t atf_temp_lookup_V11[NUM_TEMP_POINTS] = {
-//    mV, Temp(x10)
-// mV Values are calibrated on 3.45V rail
-// as that is how much the ATF sensor power gets
-    {436, -500},
-    {449, -400},
-    {462, -300},
-    {477, -200},
-    {492, -100},
-    {508, 0},
-    {524, 100},
-    {541, 200},
-    {550, 250},
-    {558, 300},
-    {576, 400},
-    {595, 500},
-    {614, 600},
-    {634, 700},
-    {654, 800},
-    {674, 900},
-    {695, 1000},
-    {716, 1100},
-    {738, 1200},
-    {749, 1250},
-    {760, 1300},
-    {782, 1400},
-    {804, 1500},
-    {827, 1600},
-    {850, 1700},
+const static temp_reading_t TFT_RESISTANCE_TAB[NUM_TEMP_POINTS] = {
+// Resistance (Ohm), Temp(x10)
+    {500, -550},
+    {525, -500},
+    {577, -400},
+    {632, -300},
+    {691, -200},
+    {754, -100},
+    {820, 0},
+    {889, 100},
+    {962, 200},
+    {1000, 250},
+    {1039, 300},
+    {1118, 400},
+    {1202, 500},
+    {1288, 600},
+    {1379, 700},
+    {1472, 800},
+    {1569, 900},
+    {1670, 1000},
+    {1774, 1100},
+    {1882, 1200},
+    {1937, 1250},
+    {1993, 1300},
+    {2107, 1400},
+    {2225, 1500},
+    {2346, 1600},
+    {2471, 1700},
+    {2535, 1750},
 };
 
 struct SensorFuncData {
@@ -84,7 +52,7 @@ struct SensorFuncData {
     //adc2_channel_t atf_channel;
     adc_channel_t adc_batt;
     adc_channel_t adc_atf;
-    const temp_reading_t* atf_calibration_curve;
+    uint16_t atf_r2_resistance;
     float current_sense_multi;
 } ;
 

--- a/src/sensors.cpp
+++ b/src/sensors.cpp
@@ -110,20 +110,20 @@ void Sensors::update(SensorDataRaw* dest) {
             adc_cali_raw_to_voltage(adc2_cal, adc_res, &adc_voltage);
 
             int resistance = (adc_voltage * pcb_gpio_matrix->sensor_data.atf_r2_resistance) / (3300 - adc_voltage);
-            if (resistance <= TFT_RESISTANCE_TAB[0].r_ohm)
+            if (TFT_RESISTANCE_TAB[0].r_ohm >= resistance)
             {
-                dest->atf_temp_c = (int16_t)(TFT_RESISTANCE_TAB[0].temp) / 10.0;
+                dest->atf_temp_c = TFT_RESISTANCE_TAB[0].temp / 10;
             }
-            else if (resistance >= TFT_RESISTANCE_TAB[NUM_TEMP_POINTS - 1].r_ohm)
+            else if (TFT_RESISTANCE_TAB[NUM_TEMP_POINTS - 1].r_ohm <= resistance)
             {   
-                dest->atf_temp_c = (int16_t)((TFT_RESISTANCE_TAB[NUM_TEMP_POINTS - 1].temp)) / 10.0;
+                dest->atf_temp_c = TFT_RESISTANCE_TAB[NUM_TEMP_POINTS - 1].temp / 10;
             }
             else
             {
                 for (uint8_t i = 0; i < NUM_TEMP_POINTS - 1; i++)
                 {
                     // Found! Interpolate linearly to get a better estimate of ATF Temp
-                    if (TFT_RESISTANCE_TAB[i].r_ohm <= resistance && TFT_RESISTANCE_TAB[i + 1].r_ohm >= resistance)
+                    if (TFT_RESISTANCE_TAB[i].r_ohm < resistance && TFT_RESISTANCE_TAB[i + 1].r_ohm > resistance)
                     {
                         dest->atf_temp_c = interpolate_int(
                             resistance, // Read voltage


### PR DESCRIPTION
This PR improves the accuracy of the TFT Sensor by changing the way the temperature is calculated:

##  Before:
1. ADC Voltage is gathered
2. Lookup in a voltage -> Temperature chart (Manually created)

## Now
1. ADC voltage is gathered
2. Voltage is converted to  resistance based on a known R2 value for the voltage divider (In PCB config)
3. Resistance is converted directly to temperature using values directly  from the temperature sensors datasheet