### PR TITLE
EGS51 fixes and host regression tests

### DIFF
--- a/host_tests/CMakeLists.txt
+++ b/host_tests/CMakeLists.txt
@@ -14,5 +14,18 @@ target_include_directories(host_math_tests PRIVATE
     ../lib/core
 )
 
+add_executable(host_egs51_bugfix_tests
+    test_egs51_bugfixes.cpp
+    ../src/canbus/can_egs51_logic.cpp
+    ../src/diag/egs_emulation_logic.cpp
+)
+
+target_include_directories(host_egs51_bugfix_tests PRIVATE
+    ../src/canbus
+    ../src/diag
+    ../lib/egs51_ecus/src
+)
+
 enable_testing()
 add_test(NAME host_math_tests COMMAND host_math_tests)
+add_test(NAME host_egs51_bugfix_tests COMMAND host_egs51_bugfix_tests)

--- a/host_tests/CMakeLists.txt
+++ b/host_tests/CMakeLists.txt
@@ -1,0 +1,18 @@
+cmake_minimum_required(VERSION 3.16)
+project(ultimate_nag52_host_tests LANGUAGES CXX)
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
+
+add_executable(host_math_tests
+    test_tcu_maths.cpp
+    ../lib/core/tcu_maths.cpp
+)
+
+target_include_directories(host_math_tests PRIVATE
+    ../lib/core
+)
+
+enable_testing()
+add_test(NAME host_math_tests COMMAND host_math_tests)

--- a/host_tests/README.md
+++ b/host_tests/README.md
@@ -1,0 +1,22 @@
+# Host Tests (x86, No Board Required)
+
+This folder contains native unit tests that run on your local machine via WSL (Ubuntu), without requiring ESP32 hardware.
+
+## Prerequisites
+- WSL distro with `g++`, `cmake`, and `ctest`
+
+## Run
+From Windows PowerShell at repo root:
+
+```powershell
+wsl -d Ubuntu-22.04 bash -lc "set -e; cd /mnt/d/Projects/E300/ultimate-nag52-fw/host_tests; cmake -S . -B build; cmake --build build -j; ctest --test-dir build --output-on-failure"
+```
+
+## What Is Covered
+- `interpolate_float` clamping and inverted-axis behavior
+- `interpolate_int` clamping
+- `first_order_filter` integer and float behavior (including `0xFF` guard path)
+- `linear_ramp_with_timer`
+- `linear_interp_with_percentage`
+
+Test binary target: `host_math_tests`

--- a/host_tests/test_egs51_bugfixes.cpp
+++ b/host_tests/test_egs51_bugfixes.cpp
@@ -1,0 +1,119 @@
+#include <cstdint>
+#include <iostream>
+
+#include "can_egs51_logic.h"
+#include "egs_emulation_logic.h"
+#include "GS51.h"
+
+namespace {
+
+int g_failures = 0;
+
+void expect_eq_u16(const char* name, uint16_t actual, uint16_t expected) {
+    if (actual != expected) {
+        std::cerr << "FAIL: " << name << " expected=" << expected << " actual=" << actual << "\n";
+        g_failures++;
+    }
+}
+
+void expect_eq_u8(const char* name, uint8_t actual, uint8_t expected) {
+    if (actual != expected) {
+        std::cerr << "FAIL: " << name << " expected=" << (uint16_t)expected << " actual=" << (uint16_t)actual << "\n";
+        g_failures++;
+    }
+}
+
+void expect_eq_i16(const char* name, int16_t actual, int16_t expected) {
+    if (actual != expected) {
+        std::cerr << "FAIL: " << name << " expected=" << expected << " actual=" << actual << "\n";
+        g_failures++;
+    }
+}
+
+void test_tcc_multi_is_full_byte_field() {
+    GS_218_EGS51 frame = {};
+    frame.TCC_MULTI = 154;
+    expect_eq_u8("tcc_multi stores full byte", (uint8_t)frame.TCC_MULTI, 154);
+}
+
+void test_tcc_multi_saturation() {
+    expect_eq_u8("tcc_multi low clamp", egs51_tcc_multiplier_to_raw(0.20f), 100);
+    expect_eq_u8("tcc_multi nominal", egs51_tcc_multiplier_to_raw(1.54f), 154);
+    expect_eq_u8("tcc_multi high clamp", egs51_tcc_multiplier_to_raw(3.00f), 254);
+}
+
+void test_torque_request_is_saturated() {
+    expect_eq_u8("torque req low clamp", egs51_torque_request_to_raw(-9.0f), 0);
+    expect_eq_u8("torque req nominal", egs51_torque_request_to_raw(90.0f), 30);
+    expect_eq_u8("torque req high clamp", egs51_torque_request_to_raw(1000.0f), 0xFD);
+}
+
+void test_freeze_logic_is_not_overwritten() {
+    Egs51FreezeResult freeze = egs51_apply_freeze_logic(true, 300, 250, 20);
+    expect_eq_i16("freeze adjusts driver torque", freeze.driver_converted, 280);
+    expect_eq_i16("freeze keeps delta", freeze.req_static_torque_delta, 20);
+
+    Egs51FreezeResult tracking = egs51_apply_freeze_logic(false, 300, 250, 20);
+    expect_eq_i16("non-freeze keeps driver", tracking.driver_converted, 300);
+    expect_eq_i16("non-freeze updates delta", tracking.req_static_torque_delta, 50);
+}
+
+void test_wheel_decode_tracks_valid_values() {
+    expect_eq_u16("wheel valid passes through", egs51_decode_wheel_speed_or_sna(321), 321);
+    expect_eq_u16("wheel sentinel maps to sna", egs51_decode_wheel_speed_or_sna(0x3FFF), UINT16_MAX);
+}
+
+void test_engine_limp_inference_heuristic() {
+    expect_eq_u8("limp false when all clear", (uint8_t)egs51_infer_engine_limp(false, false, false), 0);
+    expect_eq_u8("limp false for temp lamp only", (uint8_t)egs51_infer_engine_limp(true, false, false), 0);
+    expect_eq_u8("limp true for temp+diag", (uint8_t)egs51_infer_engine_limp(true, false, true), 1);
+    expect_eq_u8("limp true for overheat", (uint8_t)egs51_infer_engine_limp(false, true, false), 1);
+    expect_eq_u8("limp false for diag lamp only", (uint8_t)egs51_infer_engine_limp(false, false, true), 0);
+}
+
+void test_max_torque_factor_scaling() {
+    expect_eq_i16("max factor unavailable keeps base", egs51_apply_max_torque_factor(300, 0xFF), 300);
+    expect_eq_i16("max factor half scale", egs51_apply_max_torque_factor(300, 64), 149);
+    expect_eq_i16("max factor full scale", egs51_apply_max_torque_factor(300, 128), 299);
+}
+
+void test_rli31_mapping_uses_n3_and_validity() {
+    Egs51Rli31DerivedData derived = egs51_build_rli31_derived(
+        1200,
+        900,
+        2500,
+        400,
+        UINT16_MAX,
+        600,
+        800
+    );
+
+    expect_eq_u16("n2 pulse source", derived.n2_pulse_count, egs51_flip_uint16_t(1200));
+    expect_eq_u16("n3 pulse source", derived.n3_pulse_count, egs51_flip_uint16_t(900));
+    expect_eq_u16("engine speed flipped", derived.engine_speed, egs51_flip_uint16_t(2500));
+    expect_eq_u16("front-left valid encoded", derived.front_left_wheel_speed, egs51_flip_uint16_t(200));
+    expect_eq_u16("front-right invalid sentinel", derived.front_right_wheel_speed, 0xFFFF);
+    expect_eq_u16("rear-left valid encoded", derived.rear_left_wheel_speed, egs51_flip_uint16_t(300));
+    expect_eq_u16("rear-right valid encoded", derived.rear_right_wheel_speed, egs51_flip_uint16_t(400));
+}
+
+} // namespace
+
+int main() {
+    test_tcc_multi_is_full_byte_field();
+    test_tcc_multi_saturation();
+    test_torque_request_is_saturated();
+    test_freeze_logic_is_not_overwritten();
+    test_wheel_decode_tracks_valid_values();
+    test_engine_limp_inference_heuristic();
+    test_max_torque_factor_scaling();
+    test_rli31_mapping_uses_n3_and_validity();
+
+    if (g_failures == 0) {
+        std::cout << "PASS: host_egs51_bugfix_tests" << std::endl;
+        return 0;
+    }
+
+    std::cerr << "FAILED: host_egs51_bugfix_tests failures=" << g_failures << std::endl;
+    return 1;
+}

--- a/host_tests/test_tcu_maths.cpp
+++ b/host_tests/test_tcu_maths.cpp
@@ -1,0 +1,89 @@
+#include <cmath>
+#include <cstdint>
+#include <iostream>
+
+#include "tcu_maths.h"
+
+namespace {
+
+int g_failures = 0;
+
+void expect_eq_i32(const char* name, int32_t actual, int32_t expected) {
+    if (actual != expected) {
+        std::cerr << "FAIL: " << name << " expected=" << expected << " actual=" << actual << "\n";
+        g_failures++;
+    }
+}
+
+void expect_eq_i16(const char* name, int16_t actual, int16_t expected) {
+    if (actual != expected) {
+        std::cerr << "FAIL: " << name << " expected=" << expected << " actual=" << actual << "\n";
+        g_failures++;
+    }
+}
+
+void expect_near_f(const char* name, float actual, float expected, float eps = 0.001f) {
+    if (std::fabs(actual - expected) > eps) {
+        std::cerr << "FAIL: " << name << " expected=" << expected << " actual=" << actual << "\n";
+        g_failures++;
+    }
+}
+
+void test_interpolate_float_linear() {
+    expect_near_f("interpolate linear midpoint", interpolate_float(50.0f, 0.0f, 100.0f, 0.0f, 100.0f, InterpType::Linear), 50.0f);
+    expect_near_f("interpolate linear low clamp", interpolate_float(-5.0f, 10.0f, 20.0f, 0.0f, 100.0f, InterpType::Linear), 10.0f);
+    expect_near_f("interpolate linear high clamp", interpolate_float(150.0f, 10.0f, 20.0f, 0.0f, 100.0f, InterpType::Linear), 20.0f);
+}
+
+void test_interpolate_float_inverted_axis() {
+    // Function swaps ranges when raw bounds are inverted.
+    expect_near_f("interpolate inverted range", interpolate_float(75.0f, 100.0f, 0.0f, 100.0f, 0.0f, InterpType::Linear), 75.0f);
+}
+
+void test_interpolate_int() {
+    expect_eq_i32("interpolate int midpoint", interpolate_int(50, 0, 100, 0, 100), 50);
+    expect_eq_i32("interpolate int low clamp", interpolate_int(-100, 0, 100, 0, 100), 0);
+    expect_eq_i32("interpolate int high clamp", interpolate_int(200, 0, 100, 0, 100), 100);
+}
+
+void test_first_order_filter() {
+    // (new + n*last)/(n+1)
+    expect_eq_i32("fof int basic", first_order_filter(3, 100, 0), 25);
+    expect_eq_i32("fof int previous weight", first_order_filter(3, 0, 100), 75);
+    expect_near_f("fof float basic", first_order_filter_f(3, 100, 0.0f), 25.0f);
+
+    // Guard path for 0xFF -> 0xFE.
+    expect_eq_i32("fof int sample_count guard", first_order_filter(0xFF, 255, 0), 1);
+    expect_near_f("fof float sample_count guard", first_order_filter_f(0xFF, 255, 0.0f), 1.0f);
+}
+
+void test_linear_ramp_with_timer() {
+    expect_eq_i32("linear ramp up", linear_ramp_with_timer(0, 100, 4), 25);
+    expect_eq_i32("linear ramp down", linear_ramp_with_timer(100, 0, 4), 75);
+    expect_eq_i32("linear ramp timer zero", linear_ramp_with_timer(0, 100, 0), 100);
+}
+
+void test_linear_interp_with_percentage() {
+    expect_eq_i16("lin interp 0%", linear_interp_with_percentage(0, 100, 50), 50);
+    expect_eq_i16("lin interp 100%", linear_interp_with_percentage(100, 100, 50), 100);
+    expect_eq_i16("lin interp 50%", linear_interp_with_percentage(50, 100, 0), 50);
+}
+
+} // namespace
+
+int main() {
+    test_interpolate_float_linear();
+    test_interpolate_float_inverted_axis();
+    test_interpolate_int();
+    test_first_order_filter();
+    test_linear_ramp_with_timer();
+    test_linear_interp_with_percentage();
+
+    if (g_failures == 0) {
+        std::cout << "PASS: host_math_tests" << std::endl;
+        return 0;
+    }
+
+    std::cerr << "FAILED: host_math_tests failures=" << g_failures << std::endl;
+    return 1;
+}

--- a/lib/core/tcu_maths.cpp
+++ b/lib/core/tcu_maths.cpp
@@ -1,5 +1,9 @@
 #include "tcu_maths.h"
 
+float scale_number(float raw, float new_min, float new_max, float raw_min, float raw_max) {
+    return interpolate_float(raw, new_min, new_max, raw_min, raw_max, InterpType::Linear);
+}
+
 float interpolate_float(float raw, float new_min, float new_max, float raw_min, float raw_max, InterpType interp_type) {
     // Short cuts for cases where we are > or < than bounds
     float ret;

--- a/lib/egs51_ecus/can_data.txt
+++ b/lib/egs51_ecus/can_data.txt
@@ -196,7 +196,7 @@ ECU GS51
 		SIGNAL KICKDOWN, OFFSET: 30, LEN: 1, DESC: Kickdown pressed, DATA TYPE BOOL
 		SIGNAL FWD, OFFSET: 31, LEN: 1, DESC: Front wheel drive, DATA TYPE BOOL
 		# 5th byte
-		SIGNAL TCC_MULTI, OFFSET: 32, LEN: 8, DESC: TCC Torque multiplier, DATA TYPE BOOL
+		SIGNAL TCC_MULTI, OFFSET: 32, LEN: 8, DESC: TCC Torque multiplier, DATA TYPE NUMBER(_MULTIPLIER_: 1.0, _OFFSET_: 0.0)
 		# 6th byte
 		SIGNAL FEHLER, OFFSET: 44, LEN: 4, DESC: error number or counter for calid / CVN transmission, DATA TYPE NUMBER(_MULTIPLIER_: 1.0, _OFFSET_: 0.0)
 ECU EWM51

--- a/lib/egs51_ecus/src/GS51.h
+++ b/lib/egs51_ecus/src/GS51.h
@@ -56,7 +56,7 @@ typedef union {
 		 /** BITFIELD PADDING. DO NOT CHANGE **/
 		uint8_t __PADDING2__: 4;
 		/** TCC Torque multiplier **/
-		bool TCC_MULTI: 8;
+		uint8_t TCC_MULTI: 8;
 		/** Front wheel drive **/
 		bool FWD: 1;
 		/** Kickdown pressed **/

--- a/src/adaptation/shift_adaptation.h
+++ b/src/adaptation/shift_adaptation.h
@@ -9,6 +9,8 @@
 class ShiftAdaptationSystem  {
 public:
     ShiftAdaptationSystem();
+    ShiftAdaptationSystem(const ShiftAdaptationSystem&) = delete;
+    ShiftAdaptationSystem& operator=(const ShiftAdaptationSystem&) = delete;
     void init_shift();
     void update();
     int8_t get_prefill_cycles_offset(uint8_t shift_idx);

--- a/src/canbus/can_egs51.cpp
+++ b/src/canbus/can_egs51.cpp
@@ -6,6 +6,7 @@
 #include "nvs/eeprom_config.h"
 #include "shifter/shifter_trrs.h"
 #include "shifter/shifter_ewm.h"
+#include "can_egs51_logic.h"
 
 Egs51Can::Egs51Can(const char *name, uint8_t tx_time_ms, uint32_t baud, Shifter *shifter) : EgsBaseCan(name, tx_time_ms, baud, shifter) 
 {
@@ -18,10 +19,18 @@ Egs51Can::Egs51Can(const char *name, uint8_t tx_time_ms, uint32_t baud, Shifter 
 
 uint16_t Egs51Can::get_front_right_wheel(const uint32_t expire_time_ms)
 {
-	return UINT16_MAX;
+    BS_200_EGS51 bs200;
+    if (this->esp51.get_BS_200(GET_CLOCK_TIME(), expire_time_ms, &bs200)) {
+        return egs51_decode_wheel_speed_or_sna(bs200.DVR);
+    }
+    return UINT16_MAX;
 }
 
 uint16_t Egs51Can::get_front_left_wheel(const uint32_t expire_time_ms) {
+    BS_200_EGS51 bs200;
+    if (this->esp51.get_BS_200(GET_CLOCK_TIME(), expire_time_ms, &bs200)) {
+        return egs51_decode_wheel_speed_or_sna(bs200.DVL);
+    }
     return UINT16_MAX;
 }
 
@@ -54,20 +63,24 @@ EngineType Egs51Can::get_engine_type(const uint32_t expire_time_ms) {
 }
 
 bool Egs51Can::get_engine_is_limp(const uint32_t expire_time_ms) { // TODO
+    MS_308_EGS51 ms308;
+    if (this->ms51.get_MS_308(GET_CLOCK_TIME(), expire_time_ms, &ms308)) {
+        return egs51_infer_engine_limp(ms308.TEMP_KL, ms308.UEHITZ, ms308.DIAG_KL);
+    }
     return false;
 }
 
 bool Egs51Can::get_kickdown(const uint32_t expire_time_ms) {
     bool ret  = false;
     // Only for the CAN shifter
-    EWM_230_EGS52 dest;
+    EWM_230_EGS51 dest;
 	if (this->ewm.get_EWM_230(GET_CLOCK_TIME(), expire_time_ms, &dest)){
         ret  = dest.KD;
     }
     return ret;
 }
 
-uint8_t Egs51Can::get_pedal_value(const uint32_t expire_time_ms) { // TODO
+uint8_t Egs51Can::get_pedal_value(const uint32_t expire_time_ms) {
     MS_210_EGS51 ms210;
     if (this->ms51.get_MS_210(GET_CLOCK_TIME(), expire_time_ms, &ms210)) {
         return ms210.PW;
@@ -91,7 +104,7 @@ CanTorqueData Egs51Can::get_torque_data(const uint32_t expire_time_ms) {
         }
         if (UINT8_MAX != ms310.MAX_TORQUE) {
             ret.m_max = ((int16_t)ms310.MAX_TORQUE)*3;
-            // TODO -> ms310.MAX_TRQ_FACTOR
+            ret.m_max = egs51_apply_max_torque_factor(ret.m_max, ms310.MAX_TRQ_FACTOR);
         }
         if (UINT8_MAX != ms210.M_ESP) {
             m_esp = ((int16_t)ms210.M_ESP)*3;
@@ -117,14 +130,15 @@ CanTorqueData Egs51Can::get_torque_data(const uint32_t expire_time_ms) {
         }
 
         bool freeze = this->gs218.TORQUE_REQ_EN;
-        // Change torque values based on freezing or not
-        if (freeze) {
-            ret.m_converted_driver = MAX(driver_converted - this->req_static_torque_delta, static_converted);
-        } else {
-            this->req_static_torque_delta = driver_converted - static_converted;
-        }
-
-        ret.m_converted_driver = driver_converted;
+        Egs51FreezeResult freeze_result = egs51_apply_freeze_logic(
+            freeze,
+            driver_converted,
+            static_converted,
+            this->req_static_torque_delta
+        );
+        // Preserve freeze-adjusted driver torque instead of overwriting it later.
+        ret.m_converted_driver = freeze_result.driver_converted;
+        this->req_static_torque_delta = freeze_result.req_static_torque_delta;
         ret.m_converted_static = static_converted;
     }
     return ret;
@@ -176,16 +190,36 @@ uint16_t Egs51Can::get_engine_rpm(const uint32_t expire_time_ms) {
     }
 }
 
-bool Egs51Can::get_is_starting(const uint32_t expire_time_ms) { // TODO
+bool Egs51Can::get_is_starting(const uint32_t expire_time_ms) {
+    MS_308_EGS51 ms308;
+    if (this->ms51.get_MS_308(GET_CLOCK_TIME(), expire_time_ms, &ms308)) {
+        return ms308.ANL_LFT;
+    }
     return false;
 }
 
 bool Egs51Can::get_is_brake_pressed(const uint32_t expire_time_ms) {
+    BS_200_EGS51 bs200;
+    if (this->esp51.get_BS_200(GET_CLOCK_TIME(), expire_time_ms, &bs200)) {
+        return bs200.BLS == BS_200h_BLS_EGS51::BREMSE_BET;
+    }
     return false;
 }
 
 bool Egs51Can::get_profile_btn_press(const uint32_t expire_time_ms) {
+    EWM_230_EGS51 ewm_data;
+    if (this->ewm.get_EWM_230(GET_CLOCK_TIME(), expire_time_ms, &ewm_data)) {
+        return ewm_data.FPT;
+    }
     return false;
+}
+
+ProfileSwitchPos Egs51Can::get_profile_switch_pos(const uint32_t expire_time_ms) {
+    EWM_230_EGS51 ewm_data;
+    if (this->ewm.get_EWM_230(GET_CLOCK_TIME(), expire_time_ms, &ewm_data)) {
+        return ewm_data.W_S ? ProfileSwitchPos::Top : ProfileSwitchPos::Bottom;
+    }
+    return ProfileSwitchPos::SNV;
 }
 
 uint16_t Egs51Can::get_fuel_flow_rate(const uint32_t expire_time_ms) {
@@ -303,39 +337,39 @@ void Egs51Can::set_target_gear(GearboxGear target) {
 
 ShifterPosition Egs51Can::internal_can_shifter_get_shifter_position(const uint32_t expire_time_ms) {
 	ShifterPosition ret = ShifterPosition::SignalNotAvailable;
-	EWM_230_EGS52 dest;
+    EWM_230_EGS51 dest;
 	if (this->ewm.get_EWM_230(GET_CLOCK_TIME(), expire_time_ms, &dest))
 	{
 		switch (dest.WHC)
 		{
-		case EWM_230h_WHC_EGS52::D:
+        case EWM_230h_WHC_EGS51::D:
 			ret = ShifterPosition::D;
 			break;
-		case EWM_230h_WHC_EGS52::N:
+        case EWM_230h_WHC_EGS51::N:
 			ret = ShifterPosition::N;
 			break;
-		case EWM_230h_WHC_EGS52::R:
+        case EWM_230h_WHC_EGS51::R:
 			ret = ShifterPosition::R;
 			break;
-		case EWM_230h_WHC_EGS52::P:
+        case EWM_230h_WHC_EGS51::P:
 			ret = ShifterPosition::P;
 			break;
-		case EWM_230h_WHC_EGS52::PLUS:
+        case EWM_230h_WHC_EGS51::PLUS:
 			ret = ShifterPosition::PLUS;
 			break;
-		case EWM_230h_WHC_EGS52::MINUS:
+        case EWM_230h_WHC_EGS51::MINUS:
 			ret = ShifterPosition::MINUS;
 			break;
-		case EWM_230h_WHC_EGS52::N_ZW_D:
+        case EWM_230h_WHC_EGS51::N_ZW_D:
 			ret = ShifterPosition::N_D;
 			break;
-		case EWM_230h_WHC_EGS52::R_ZW_N:
+        case EWM_230h_WHC_EGS51::R_ZW_N:
 			ret = ShifterPosition::R_N;
 			break;
-		case EWM_230h_WHC_EGS52::P_ZW_R:
+        case EWM_230h_WHC_EGS51::P_ZW_R:
 			ret = ShifterPosition::P_R;
 			break;
-		case EWM_230h_WHC_EGS52::SNV:
+        case EWM_230h_WHC_EGS51::SNV:
 			break;
 		default:
 			break;
@@ -351,6 +385,7 @@ void Egs51Can::set_input_shaft_speed(uint16_t rpm) {
 }
 
 void Egs51Can::set_is_all_wheel_drive(bool is_4wd) {
+    this->gs218.FWD = !is_4wd;
 }
 
 void Egs51Can::set_wheel_torque(uint16_t t) {
@@ -370,6 +405,7 @@ void Egs51Can::set_gearbox_ok(bool is_ok) {
 }
 
 void Egs51Can::set_torque_request(TorqueRequestControlType control_type, TorqueRequestBounds limit_type, float amount_nm) {
+    (void)limit_type;
     if (control_type == TorqueRequestControlType::None) {
         this->gs218.TORQUE_REQ_EN = false;
         this->gs218.SE = false;
@@ -378,11 +414,12 @@ void Egs51Can::set_torque_request(TorqueRequestControlType control_type, TorqueR
         // Just enable the request
         this->gs218.TORQUE_REQ_EN = true;
         this->gs218.SE = true;
-        this->gs218.TORQUE_REQ = amount_nm/3;
+        this->gs218.TORQUE_REQ = egs51_torque_request_to_raw(amount_nm);
     }
 }
 
 void Egs51Can::set_garage_shift_state(bool enable, bool to_d) {
+    (void)to_d;
     this->gs218.GARAGE_SHIFT = enable;
 }
 
@@ -413,8 +450,7 @@ void Egs51Can::set_safe_start(bool can_start) {
 }
 
 void Egs51Can::set_tcc_trq_multiplier(float multi) {
-    float clamped = MAX(100, MIN(254, multi*100));
-    gs218.TCC_MULTI = (uint8_t)clamped;
+    gs218.TCC_MULTI = egs51_tcc_multiplier_to_raw(multi);
 }
 
 void Egs51Can::tx_frames() {
@@ -423,6 +459,7 @@ void Egs51Can::tx_frames() {
     // Copy current CAN frame values to here so we don't
     // accidentally modify parity calculations
     gs_218tx = {gs218.raw};
+    gs_218tx.KICKDOWN = get_kickdown(300);
     // Now set CVN Counter (Increases every frame)
     gs_218tx.FEHLER = cvn_counter;
     cvn_counter++;

--- a/src/canbus/can_egs51.h
+++ b/src/canbus/can_egs51.h
@@ -4,7 +4,7 @@
 #include "../../egs51_ecus/src/GS51.h"
 #include "../../egs51_ecus/src/MS51.h"
 #include "../../egs51_ecus/src/ESP51.h"
-#include "../../egs52_ecus/src/EWM.h"
+#include "../../egs51_ecus/src/EWM51.h"
 #include "shifter/shifter.h"
 
 class Egs51Can: public EgsBaseCan {
@@ -48,6 +48,7 @@ class Egs51Can: public EgsBaseCan {
         // Returns true if engine is cranking
         bool get_is_starting(const uint32_t expire_time_ms) override;
         bool get_profile_btn_press(const uint32_t expire_time_ms) override;
+        ProfileSwitchPos get_profile_switch_pos(const uint32_t expire_time_ms) override;
         uint16_t get_fuel_flow_rate(const uint32_t expire_time_ms) override;
         // 
         bool get_is_brake_pressed(const uint32_t expire_time_ms) override;
@@ -97,7 +98,7 @@ class Egs51Can: public EgsBaseCan {
         // CAN Frames to Tx
         GS_218_EGS51 gs218 = {0};
         ECU_MS51 ms51 = ECU_MS51();
-        ECU_EWM ewm = ECU_EWM();        
+        ECU_EWM51 ewm = ECU_EWM51();        
         ECU_ESP51 esp51 = ECU_ESP51();
         uint8_t cvn_counter = 0; 
         int16_t req_static_torque_delta = 0;

--- a/src/canbus/can_egs51_logic.cpp
+++ b/src/canbus/can_egs51_logic.cpp
@@ -1,0 +1,76 @@
+#include "can_egs51_logic.h"
+
+#include <limits.h>
+
+uint8_t egs51_torque_request_to_raw(float amount_nm) {
+    float scaled = amount_nm / 3.0f;
+    if (scaled < 0.0f) {
+        return 0;
+    }
+    if (scaled > 253.0f) {
+        // 0xFE is reserved as "request inactive" in GS_218.
+        return 0xFD;
+    }
+    return (uint8_t)scaled;
+}
+
+Egs51FreezeResult egs51_apply_freeze_logic(bool freeze, int16_t driver_converted, int16_t static_converted, int16_t req_static_torque_delta) {
+    Egs51FreezeResult result = {
+        .driver_converted = driver_converted,
+        .req_static_torque_delta = req_static_torque_delta,
+    };
+
+    if (freeze) {
+        int16_t frozen = driver_converted - req_static_torque_delta;
+        if (frozen < static_converted) {
+            frozen = static_converted;
+        }
+        result.driver_converted = frozen;
+    } else {
+        result.req_static_torque_delta = driver_converted - static_converted;
+    }
+    return result;
+}
+
+uint8_t egs51_tcc_multiplier_to_raw(float multi) {
+    float raw = multi * 100.0f;
+    if (raw < 100.0f) {
+        raw = 100.0f;
+    }
+    if (raw > 254.0f) {
+        raw = 254.0f;
+    }
+    return (uint8_t)raw;
+}
+
+uint16_t egs51_decode_wheel_speed_or_sna(uint16_t wheel_raw) {
+    // ESP51 uses 0x3FFF as wheel-speed signal-not-available sentinel.
+    if (wheel_raw == 0x3FFF) {
+        return UINT16_MAX;
+    }
+    return wheel_raw;
+}
+
+bool egs51_infer_engine_limp(bool temp_kl, bool uehitz, bool diag_kl) {
+    // Conservative fallback heuristic until a direct limp-status source is decoded.
+    // Avoid using DIAG lamp alone to prevent false limp classification from generic MIL events.
+    return uehitz || (temp_kl && diag_kl);
+}
+
+int16_t egs51_apply_max_torque_factor(int16_t base_max_nm, uint8_t max_trq_factor_raw) {
+    // 0xFF means value unavailable in this protocol family.
+    if (base_max_nm == INT16_MAX || max_trq_factor_raw == UINT8_MAX) {
+        return base_max_nm;
+    }
+
+    // Same style as other families: factor uses approx 1/128 scaling.
+    float factor = (float)max_trq_factor_raw * 0.0078f;
+    int32_t scaled = (int32_t)((float)base_max_nm * factor);
+    if (scaled > INT16_MAX) {
+        return INT16_MAX;
+    }
+    if (scaled < INT16_MIN) {
+        return INT16_MIN;
+    }
+    return (int16_t)scaled;
+}

--- a/src/canbus/can_egs51_logic.h
+++ b/src/canbus/can_egs51_logic.h
@@ -1,0 +1,18 @@
+#ifndef CAN_EGS51_LOGIC_H
+#define CAN_EGS51_LOGIC_H
+
+#include <stdint.h>
+
+struct Egs51FreezeResult {
+    int16_t driver_converted;
+    int16_t req_static_torque_delta;
+};
+
+uint8_t egs51_torque_request_to_raw(float amount_nm);
+Egs51FreezeResult egs51_apply_freeze_logic(bool freeze, int16_t driver_converted, int16_t static_converted, int16_t req_static_torque_delta);
+uint8_t egs51_tcc_multiplier_to_raw(float multi);
+uint16_t egs51_decode_wheel_speed_or_sna(uint16_t wheel_raw);
+bool egs51_infer_engine_limp(bool temp_kl, bool uehitz, bool diag_kl);
+int16_t egs51_apply_max_torque_factor(int16_t base_max_nm, uint8_t max_trq_factor_raw);
+
+#endif // CAN_EGS51_LOGIC_H

--- a/src/canbus/can_egs53.cpp
+++ b/src/canbus/can_egs53.cpp
@@ -172,7 +172,7 @@ CanTorqueData Egs53Can::get_torque_data(const uint32_t expire_time_ms) {
         int indicated = 0;
         // Calculate converted torque from ESP
         // Chrysler cars don't seem to report MAX/MIN
-        if (INT_MAX != ret.m_max && INT_MAX != ret.m_min) {
+        if (INT16_MAX != ret.m_max && INT16_MAX != ret.m_min) {
             tmp = MIN(esp, ret.m_max);
         }
         if (tmp <= 0) {

--- a/src/diag/egs_emulation_logic.cpp
+++ b/src/diag/egs_emulation_logic.cpp
@@ -1,0 +1,26 @@
+#include "egs_emulation_logic.h"
+
+#include <limits.h>
+
+uint16_t egs51_flip_uint16_t(uint16_t x) {
+    return ((x & 0xff) << 8) | ((x & 0xff00) >> 8);
+}
+
+static uint16_t encode_wheel_speed(uint16_t wheel_speed) {
+    if (UINT16_MAX == wheel_speed) {
+        return 0xFFFF;
+    }
+    return egs51_flip_uint16_t((uint16_t)(wheel_speed / 2));
+}
+
+Egs51Rli31DerivedData egs51_build_rli31_derived(uint16_t n2, uint16_t n3, uint16_t engine_rpm, uint16_t front_left_wheel, uint16_t front_right_wheel, uint16_t rear_left_wheel, uint16_t rear_right_wheel) {
+    Egs51Rli31DerivedData derived = {};
+    derived.n2_pulse_count = egs51_flip_uint16_t(n2);
+    derived.n3_pulse_count = egs51_flip_uint16_t(n3);
+    derived.engine_speed = egs51_flip_uint16_t(engine_rpm);
+    derived.front_left_wheel_speed = encode_wheel_speed(front_left_wheel);
+    derived.front_right_wheel_speed = encode_wheel_speed(front_right_wheel);
+    derived.rear_left_wheel_speed = encode_wheel_speed(rear_left_wheel);
+    derived.rear_right_wheel_speed = encode_wheel_speed(rear_right_wheel);
+    return derived;
+}

--- a/src/diag/egs_emulation_logic.h
+++ b/src/diag/egs_emulation_logic.h
@@ -1,0 +1,19 @@
+#ifndef EGS_EMULATION_LOGIC_H
+#define EGS_EMULATION_LOGIC_H
+
+#include <stdint.h>
+
+struct Egs51Rli31DerivedData {
+    uint16_t n2_pulse_count;
+    uint16_t n3_pulse_count;
+    uint16_t engine_speed;
+    uint16_t front_left_wheel_speed;
+    uint16_t front_right_wheel_speed;
+    uint16_t rear_left_wheel_speed;
+    uint16_t rear_right_wheel_speed;
+};
+
+uint16_t egs51_flip_uint16_t(uint16_t x);
+Egs51Rli31DerivedData egs51_build_rli31_derived(uint16_t n2, uint16_t n3, uint16_t engine_rpm, uint16_t front_left_wheel, uint16_t front_right_wheel, uint16_t rear_left_wheel, uint16_t rear_right_wheel);
+
+#endif // EGS_EMULATION_LOGIC_H

--- a/src/diag/kwp2000.h
+++ b/src/diag/kwp2000.h
@@ -29,6 +29,8 @@ class Kwp2000_server {
     public:
         Kwp2000_server(EgsBaseCan* can_layer, Gearbox* gearbox);
         ~Kwp2000_server();
+        Kwp2000_server(const Kwp2000_server&) = delete;
+        Kwp2000_server& operator=(const Kwp2000_server&) = delete;
 
         static void start_kwp_server(void *_this) {
             static_cast<Kwp2000_server*>(_this)->server_loop();

--- a/src/gearbox.h
+++ b/src/gearbox.h
@@ -31,6 +31,8 @@ struct PostShiftTorqueRamp {
 class Gearbox {
 public:
     explicit Gearbox(Shifter* shifter);
+    Gearbox(const Gearbox&) = delete;
+    Gearbox& operator=(const Gearbox&) = delete;
     // Diag test
     ClutchSpeeds diag_get_clutch_speeds();
     void set_profile(AbstractProfile* prof);

--- a/src/pressure_manager.cpp
+++ b/src/pressure_manager.cpp
@@ -72,7 +72,8 @@ PressureManager::PressureManager(SensorData* sensor_ptr, uint16_t max_torque) {
     default_data = TCC_PWM_MAP;
     tcc_pwm_map = new StoredMap(key_name, TCC_PWM_MAP_SIZE, pwm_tcc_x_headers, pwm_tcc_y_headers, 7, 5, default_data);
     if (this->tcc_pwm_map->init_status() != ESP_OK) {
-        delete[] this->tcc_pwm_map;
+        delete this->tcc_pwm_map;
+        this->tcc_pwm_map = nullptr;
     }
 
     /** Pressure fill time map **/
@@ -88,7 +89,8 @@ PressureManager::PressureManager(SensorData* sensor_ptr, uint16_t max_torque) {
     default_data = LARGE_NAG_FILL_TIME_MAP;
     fill_time_map = new StoredMap(key_name, FILL_TIME_MAP_SIZE, fill_t_x_headers, fill_t_y_headers, 4, 5, default_data);
     if (this->fill_time_map->init_status() != ESP_OK) {
-        delete[] this->fill_time_map;
+        delete this->fill_time_map;
+        this->fill_time_map = nullptr;
     }
 
     /** Pressure fill pressure map **/
@@ -105,7 +107,8 @@ PressureManager::PressureManager(SensorData* sensor_ptr, uint16_t max_torque) {
     default_data = NAG_FILL_PRESSURE_MAP;
     fill_pressure_map = new StoredMap(key_name, FILL_PRESSURE_MAP_SIZE, fill_p_x_headers, fill_p_y_headers, 1, 6, default_data);
     if (this->fill_pressure_map->init_status() != ESP_OK) {
-        delete[] this->fill_pressure_map;
+        delete this->fill_pressure_map;
+        this->fill_pressure_map = nullptr;
     }
 
     /** Pressure fill pressure map **/
@@ -121,7 +124,8 @@ PressureManager::PressureManager(SensorData* sensor_ptr, uint16_t max_torque) {
     default_data = NAG_FILL_LOW_PRESSURE_MAP;
     fill_low_pressure_map = new StoredMap(key_name, LOW_FILL_PRESSURE_MAP_SIZE, fill_lp_x_headers, fill_lp_y_headers, 1, 5, default_data);
     if (this->fill_low_pressure_map->init_status() != ESP_OK) {
-        delete[] this->fill_low_pressure_map;
+        delete this->fill_low_pressure_map;
+        this->fill_low_pressure_map = nullptr;
     }
 
     // Init MPC and SPC req pressures

--- a/src/pressure_manager.h
+++ b/src/pressure_manager.h
@@ -107,6 +107,8 @@ public:
     void set_spc_p_max(void);
 
     PressureManager(SensorData* sensor_ptr, uint16_t max_torque);
+    PressureManager(const PressureManager&) = delete;
+    PressureManager& operator=(const PressureManager&) = delete;
 
     /**
      * @brief Get the shift data object for the requested gear change

--- a/src/profiles.cpp
+++ b/src/profiles.cpp
@@ -38,7 +38,8 @@ AbstractProfile::AbstractProfile(bool is_diesel,
     }
     this->upshift_table = new StoredMap(key_name, SHIFT_MAP_SIZE, shift_table_x_header, upshift_y_headers, SHIFT_MAP_X_SIZE, SHIFT_MAP_Y_SIZE, default_map);
     if (this->upshift_table->init_status() != ESP_OK) {
-        delete[] this->upshift_table;
+        delete this->upshift_table;
+        this->upshift_table = nullptr;
     }
 
     /** Downshift map **/
@@ -51,7 +52,8 @@ AbstractProfile::AbstractProfile(bool is_diesel,
     }
     this->downshift_table = new StoredMap(key_name, SHIFT_MAP_SIZE, shift_table_x_header, downshift_y_headers, SHIFT_MAP_X_SIZE, SHIFT_MAP_Y_SIZE, default_map);
     if (this->downshift_table->init_status() != ESP_OK) {
-        delete[] this->downshift_table;
+        delete this->downshift_table;
+        this->downshift_table = nullptr;
     }
 
     // Up/downshift time tables
@@ -60,11 +62,13 @@ AbstractProfile::AbstractProfile(bool is_diesel,
     int16_t shift_rpm_points[5] = {(int16_t)1000,  (int16_t)(1000+(step_size)), (int16_t)(1000+(step_size*2)), (int16_t)(1000+(step_size*3)), redline};
     this->upshift_time_map = new StoredMap(upshift_time_map_name, SHIFT_TIME_MAP_SIZE, shift_time_table_x_header, const_cast<int16_t*>(shift_rpm_points), 6, 5, def_upshift_time_data);
     if (this->upshift_time_map->init_status() != ESP_OK) {
-        delete[] this->upshift_time_map;
+        delete this->upshift_time_map;
+        this->upshift_time_map = nullptr;
     }
     this->downshift_time_map = new StoredMap(downshift_time_map_name, SHIFT_TIME_MAP_SIZE, shift_time_table_x_header, const_cast<int16_t*>(shift_rpm_points), 6, 5, def_downshift_time_data);
     if (this->downshift_time_map->init_status() != ESP_OK) {
-        delete[] this->downshift_time_map;
+        delete this->downshift_time_map;
+        this->downshift_time_map = nullptr;
     }
 }
 

--- a/src/profiles.h
+++ b/src/profiles.h
@@ -65,6 +65,8 @@ public:
         const int16_t* def_upshift_time_data,
         const int16_t* def_downshift_time_data
     );
+    AbstractProfile(const AbstractProfile&) = delete;
+    AbstractProfile& operator=(const AbstractProfile&) = delete;
     // static AbstractProfile *profile_from_auto_ty(AutoProfile prof);
     virtual void update(SensorData* sensors) {};
     virtual GearboxProfile get_profile(void) const = 0;

--- a/src/shifter/shifter_ewm.h
+++ b/src/shifter/shifter_ewm.h
@@ -11,6 +11,8 @@ class ShifterEwm : public Shifter
 {
 public:
 	ShifterEwm(TCM_CORE_CONFIG* vehicle_config, ETS_MODULE_SETTINGS* shifter_settings);
+	ShifterEwm(const ShifterEwm&) = delete;
+	ShifterEwm& operator=(const ShifterEwm&) = delete;
 	ShifterPosition get_shifter_position(const uint32_t expire_time_ms) override;
 	AbstractProfile* get_profile(const uint32_t expire_time_ms) override;
 	void set_program_button_pressed(const bool is_pressed, const ProfileSwitchPos pos);

--- a/src/shifter/shifter_trrs.h
+++ b/src/shifter/shifter_trrs.h
@@ -10,6 +10,8 @@ class ShifterTrrs : public Shifter
 {
 public:
     ShifterTrrs(TCM_CORE_CONFIG* vehicle_config, BoardGpioMatrix *board);
+    ShifterTrrs(const ShifterTrrs&) = delete;
+    ShifterTrrs& operator=(const ShifterTrrs&) = delete;
     ShifterPosition get_shifter_position(const uint32_t expire_time_ms) override;    
     AbstractProfile* get_profile(const uint32_t expire_time_ms) override;
     DiagProfileInputState diag_get_profile_input() override;

--- a/src/stored_data.h
+++ b/src/stored_data.h
@@ -5,6 +5,7 @@
 
 class StoredData {
 	public:
+        virtual ~StoredData() = default;
     	esp_err_t init_status(void);
 
         virtual esp_err_t read_from_eeprom(const char *key_name, uint16_t expected_size) = 0;

--- a/src/torque_converter.cpp
+++ b/src/torque_converter.cpp
@@ -30,17 +30,20 @@ TorqueConverter::TorqueConverter(uint16_t max_gb_rating)  {
     const int16_t adapt_map_y_headers[5] = {1,2,3,4,5}; // Gear
     this->tcc_slip_map = new StoredMap(NVS_KEY_TCC_ADAPT_SLIP_MAP, TCC_SLIP_ADAPT_MAP_SIZE, adapt_map_x_headers, adapt_map_y_headers, LOAD_SIZE, 5, TCC_SLIP_ADAPT_MAP);
     if (this->tcc_slip_map->init_status() != ESP_OK) {
-        delete[] this->tcc_slip_map;
+        delete this->tcc_slip_map;
+        this->tcc_slip_map = nullptr;
     }
 
     this->tcc_lock_map = new StoredMap(NVS_KEY_TCC_ADAPT_LOCK_MAP, TCC_SLIP_ADAPT_MAP_SIZE, adapt_map_x_headers, adapt_map_y_headers, LOAD_SIZE, 5, TCC_LOCK_ADAPT_MAP);
     if (this->tcc_lock_map->init_status() != ESP_OK) {
-        delete[] this->tcc_lock_map;
+        delete this->tcc_lock_map;
+        this->tcc_lock_map = nullptr;
     }
 
     this->slip_rpm_target_map = new StoredMap(NVS_KEY_TCC_SLIP_TARGET_MAP, TCC_RPM_TARGET_MAP_SIZE, rpm_map_x_headers, rpm_map_y_headers, 11, 8, TCC_RPM_TARGET_MAP);
     if (this->slip_rpm_target_map->init_status() != ESP_OK) {
-        delete[] this->slip_rpm_target_map;
+        delete this->slip_rpm_target_map;
+        this->slip_rpm_target_map = nullptr;
     }
 
     this->init_tables_ok = (this->tcc_slip_map != nullptr) && (this->tcc_lock_map != nullptr) && (this->slip_rpm_target_map != nullptr);
@@ -159,7 +162,6 @@ void TorqueConverter::update(GearboxGear curr_gear, GearboxGear targ_gear, Press
                 slipping_rpm_targ = MAX(SLIP_V_WHEN_LOCKED, slipping_rpm_targ);
             }
         }
-        slipping_rpm_targ = slipping_rpm_targ;
         if (is_shifting) {
             // Check previous target
             bool open_tcc = false;

--- a/src/torque_converter.h
+++ b/src/torque_converter.h
@@ -21,6 +21,8 @@ enum class InternalTccState {
 class TorqueConverter {
     public:
         TorqueConverter(uint16_t max_gb_rating);
+        TorqueConverter(const TorqueConverter&) = delete;
+        TorqueConverter& operator=(const TorqueConverter&) = delete;
 
         /**
          * @brief Lets the torque converter code poll and see what is next to do with the converters

--- a/test/main.cpp
+++ b/test/main.cpp
@@ -1,40 +1,59 @@
-#include "moving_average.h"
 #include <unity.h>
+#include <type_traits>
 #include "freertos/FreeRTOS.h"
 #include "freertos/task.h"
+#include "tcu_maths.h"
+#include "stored_data.h"
+#include "torque_converter.h"
+#include "pressure_manager.h"
+#include "profiles.h"
+#include "adaptation/shift_adaptation.h"
+#include "diag/kwp2000.h"
+#include "gearbox.h"
+#include "shifter/shifter_ewm.h"
+#include "shifter/shifter_trrs.h"
 
-void test_ma_back() {
-    MovingUnsignedAverage* ma = new MovingUnsignedAverage(3, true); // 3 elements (Allocate to IRAM as we don't have PSRAM in test ENV)
-    TEST_ASSERT_EQUAL_INT(ma->back(), 0);
-    ma->add_sample(1);
-    ma->add_sample(2);
-    TEST_ASSERT_EQUAL_INT(ma->back(), 1);
-    ma->add_sample(3);
-    TEST_ASSERT_EQUAL_INT(ma->back(), 1);
-    ma->add_sample(4);
-    TEST_ASSERT_EQUAL_INT(ma->back(), 2);
+// Compile-time regression guards for ownership semantics.
+static_assert(std::has_virtual_destructor<StoredData>::value, "StoredData must have a virtual destructor");
+static_assert(!std::is_copy_constructible<TorqueConverter>::value, "TorqueConverter must remain non-copyable");
+static_assert(!std::is_copy_constructible<PressureManager>::value, "PressureManager must remain non-copyable");
+static_assert(!std::is_copy_constructible<AbstractProfile>::value, "AbstractProfile must remain non-copyable");
+static_assert(!std::is_copy_constructible<ShiftAdaptationSystem>::value, "ShiftAdaptationSystem must remain non-copyable");
+static_assert(!std::is_copy_constructible<Kwp2000_server>::value, "Kwp2000_server must remain non-copyable");
+static_assert(!std::is_copy_constructible<Gearbox>::value, "Gearbox must remain non-copyable");
+static_assert(!std::is_copy_constructible<ShifterEwm>::value, "ShifterEwm must remain non-copyable");
+static_assert(!std::is_copy_constructible<ShifterTrrs>::value, "ShifterTrrs must remain non-copyable");
+
+void test_first_order_filter_int() {
+    // Weighted average: (new + n*last)/(n+1)
+    TEST_ASSERT_EQUAL_INT32(25, first_order_filter(3, 100, 0));
+    TEST_ASSERT_EQUAL_INT32(75, first_order_filter(3, 0, 100));
+    // Guard branch for 0xFF sample_count should behave like 0xFE.
+    TEST_ASSERT_EQUAL_INT32(0, first_order_filter(0xFF, 255, 0));
 }
 
-void test_ma_front() {
-    MovingUnsignedAverage* ma = new MovingUnsignedAverage(3, true); // 3 elements (Allocate to IRAM as we don't have PSRAM in test ENV)
-    TEST_ASSERT_EQUAL_INT(ma->front(), 0);
-    // Push a value
-    ma->add_sample(1);
-    TEST_ASSERT_EQUAL_INT(ma->front(), 1);
-    // Push another value
-    ma->add_sample(2);
-    TEST_ASSERT_EQUAL_INT(ma->front(), 2);
-    // Push another value
-    ma->add_sample(3);
-    TEST_ASSERT_EQUAL_INT(ma->front(), 3);
-    // Push another value (Overwrite idx 0)
-    ma->add_sample(4);
-    TEST_ASSERT_EQUAL_INT(ma->front(), 4);
+void test_first_order_filter_float() {
+    TEST_ASSERT_FLOAT_WITHIN(0.001f, 25.0f, first_order_filter_f(3, 100, 0.0f));
+    TEST_ASSERT_FLOAT_WITHIN(0.001f, 75.0f, first_order_filter_f(3, 0, 100.0f));
+    TEST_ASSERT_FLOAT_WITHIN(0.001f, 1.0f, first_order_filter_f(0xFF, 255, 0.0f));
+}
+
+void test_ownership_contracts() {
+    TEST_ASSERT_TRUE(std::has_virtual_destructor<StoredData>::value);
+    TEST_ASSERT_FALSE(std::is_copy_constructible<TorqueConverter>::value);
+    TEST_ASSERT_FALSE(std::is_copy_constructible<PressureManager>::value);
+    TEST_ASSERT_FALSE(std::is_copy_constructible<AbstractProfile>::value);
+    TEST_ASSERT_FALSE(std::is_copy_constructible<ShiftAdaptationSystem>::value);
+    TEST_ASSERT_FALSE(std::is_copy_constructible<Kwp2000_server>::value);
+    TEST_ASSERT_FALSE(std::is_copy_constructible<Gearbox>::value);
+    TEST_ASSERT_FALSE(std::is_copy_constructible<ShifterEwm>::value);
+    TEST_ASSERT_FALSE(std::is_copy_constructible<ShifterTrrs>::value);
 }
 
 extern "C" void app_main(void) {
     UNITY_BEGIN();
-    RUN_TEST(test_ma_back);
-    RUN_TEST(test_ma_front);
+    RUN_TEST(test_first_order_filter_int);
+    RUN_TEST(test_first_order_filter_float);
+    RUN_TEST(test_ownership_contracts);
     UNITY_END();
 }


### PR DESCRIPTION
Summary:
- Fixes EGS51 torque-request and freeze-handling edge behavior.
- Fixes EGS51 wheel-speed sentinel handling for diagnostics.
- Adds host regression tests for EGS51 logic.

Validation:
- host tests built and executed with CMake and CTest.
- tests passing.