### PR TITLE
Low-level IO hardening and host logic tests (stacked)

### DIFF
--- a/host_tests/CMakeLists.txt
+++ b/host_tests/CMakeLists.txt
@@ -14,5 +14,18 @@ target_include_directories(host_math_tests PRIVATE
     ../lib/core
 )
 
+add_executable(host_egs51_bugfix_tests
+    test_egs51_bugfixes.cpp
+    ../src/canbus/can_egs51_logic.cpp
+    ../src/diag/egs_emulation_logic.cpp
+)
+
+target_include_directories(host_egs51_bugfix_tests PRIVATE
+    ../src/canbus
+    ../src/diag
+    ../lib/egs51_ecus/src
+)
+
 enable_testing()
 add_test(NAME host_math_tests COMMAND host_math_tests)
+add_test(NAME host_egs51_bugfix_tests COMMAND host_egs51_bugfix_tests)

--- a/host_tests/CMakeLists.txt
+++ b/host_tests/CMakeLists.txt
@@ -26,6 +26,22 @@ target_include_directories(host_egs51_bugfix_tests PRIVATE
     ../lib/egs51_ecus/src
 )
 
+add_executable(host_lowlevel_logic_tests
+    test_lowlevel_logic.cpp
+    ../src/ioexpander_logic.cpp
+    ../src/inputcomponents/kickdownswitch_logic.cpp
+    ../src/canbus/can_custom_logic.cpp
+    ../src/sensors_logic.cpp
+)
+
+target_include_directories(host_lowlevel_logic_tests PRIVATE
+    ../src
+    ../src/canbus
+    ../src/inputcomponents
+    ../lib/customcan_ecus/src
+)
+
 enable_testing()
 add_test(NAME host_math_tests COMMAND host_math_tests)
 add_test(NAME host_egs51_bugfix_tests COMMAND host_egs51_bugfix_tests)
+add_test(NAME host_lowlevel_logic_tests COMMAND host_lowlevel_logic_tests)

--- a/host_tests/CMakeLists.txt
+++ b/host_tests/CMakeLists.txt
@@ -1,0 +1,18 @@
+cmake_minimum_required(VERSION 3.16)
+project(ultimate_nag52_host_tests LANGUAGES CXX)
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
+
+add_executable(host_math_tests
+    test_tcu_maths.cpp
+    ../lib/core/tcu_maths.cpp
+)
+
+target_include_directories(host_math_tests PRIVATE
+    ../lib/core
+)
+
+enable_testing()
+add_test(NAME host_math_tests COMMAND host_math_tests)

--- a/host_tests/README.md
+++ b/host_tests/README.md
@@ -1,0 +1,22 @@
+# Host Tests (x86, No Board Required)
+
+This folder contains native unit tests that run on your local machine via WSL (Ubuntu), without requiring ESP32 hardware.
+
+## Prerequisites
+- WSL distro with `g++`, `cmake`, and `ctest`
+
+## Run
+From Windows PowerShell at repo root:
+
+```powershell
+wsl -d Ubuntu-22.04 bash -lc "set -e; cd /mnt/d/Projects/E300/ultimate-nag52-fw/host_tests; cmake -S . -B build; cmake --build build -j; ctest --test-dir build --output-on-failure"
+```
+
+## What Is Covered
+- `interpolate_float` clamping and inverted-axis behavior
+- `interpolate_int` clamping
+- `first_order_filter` integer and float behavior (including `0xFF` guard path)
+- `linear_ramp_with_timer`
+- `linear_interp_with_percentage`
+
+Test binary target: `host_math_tests`

--- a/host_tests/test_egs51_bugfixes.cpp
+++ b/host_tests/test_egs51_bugfixes.cpp
@@ -1,0 +1,119 @@
+#include <cstdint>
+#include <iostream>
+
+#include "can_egs51_logic.h"
+#include "egs_emulation_logic.h"
+#include "GS51.h"
+
+namespace {
+
+int g_failures = 0;
+
+void expect_eq_u16(const char* name, uint16_t actual, uint16_t expected) {
+    if (actual != expected) {
+        std::cerr << "FAIL: " << name << " expected=" << expected << " actual=" << actual << "\n";
+        g_failures++;
+    }
+}
+
+void expect_eq_u8(const char* name, uint8_t actual, uint8_t expected) {
+    if (actual != expected) {
+        std::cerr << "FAIL: " << name << " expected=" << (uint16_t)expected << " actual=" << (uint16_t)actual << "\n";
+        g_failures++;
+    }
+}
+
+void expect_eq_i16(const char* name, int16_t actual, int16_t expected) {
+    if (actual != expected) {
+        std::cerr << "FAIL: " << name << " expected=" << expected << " actual=" << actual << "\n";
+        g_failures++;
+    }
+}
+
+void test_tcc_multi_is_full_byte_field() {
+    GS_218_EGS51 frame = {};
+    frame.TCC_MULTI = 154;
+    expect_eq_u8("tcc_multi stores full byte", (uint8_t)frame.TCC_MULTI, 154);
+}
+
+void test_tcc_multi_saturation() {
+    expect_eq_u8("tcc_multi low clamp", egs51_tcc_multiplier_to_raw(0.20f), 100);
+    expect_eq_u8("tcc_multi nominal", egs51_tcc_multiplier_to_raw(1.54f), 154);
+    expect_eq_u8("tcc_multi high clamp", egs51_tcc_multiplier_to_raw(3.00f), 254);
+}
+
+void test_torque_request_is_saturated() {
+    expect_eq_u8("torque req low clamp", egs51_torque_request_to_raw(-9.0f), 0);
+    expect_eq_u8("torque req nominal", egs51_torque_request_to_raw(90.0f), 30);
+    expect_eq_u8("torque req high clamp", egs51_torque_request_to_raw(1000.0f), 0xFD);
+}
+
+void test_freeze_logic_is_not_overwritten() {
+    Egs51FreezeResult freeze = egs51_apply_freeze_logic(true, 300, 250, 20);
+    expect_eq_i16("freeze adjusts driver torque", freeze.driver_converted, 280);
+    expect_eq_i16("freeze keeps delta", freeze.req_static_torque_delta, 20);
+
+    Egs51FreezeResult tracking = egs51_apply_freeze_logic(false, 300, 250, 20);
+    expect_eq_i16("non-freeze keeps driver", tracking.driver_converted, 300);
+    expect_eq_i16("non-freeze updates delta", tracking.req_static_torque_delta, 50);
+}
+
+void test_wheel_decode_tracks_valid_values() {
+    expect_eq_u16("wheel valid passes through", egs51_decode_wheel_speed_or_sna(321), 321);
+    expect_eq_u16("wheel sentinel maps to sna", egs51_decode_wheel_speed_or_sna(0x3FFF), UINT16_MAX);
+}
+
+void test_engine_limp_inference_heuristic() {
+    expect_eq_u8("limp false when all clear", (uint8_t)egs51_infer_engine_limp(false, false, false), 0);
+    expect_eq_u8("limp false for temp lamp only", (uint8_t)egs51_infer_engine_limp(true, false, false), 0);
+    expect_eq_u8("limp true for temp+diag", (uint8_t)egs51_infer_engine_limp(true, false, true), 1);
+    expect_eq_u8("limp true for overheat", (uint8_t)egs51_infer_engine_limp(false, true, false), 1);
+    expect_eq_u8("limp false for diag lamp only", (uint8_t)egs51_infer_engine_limp(false, false, true), 0);
+}
+
+void test_max_torque_factor_scaling() {
+    expect_eq_i16("max factor unavailable keeps base", egs51_apply_max_torque_factor(300, 0xFF), 300);
+    expect_eq_i16("max factor half scale", egs51_apply_max_torque_factor(300, 64), 149);
+    expect_eq_i16("max factor full scale", egs51_apply_max_torque_factor(300, 128), 299);
+}
+
+void test_rli31_mapping_uses_n3_and_validity() {
+    Egs51Rli31DerivedData derived = egs51_build_rli31_derived(
+        1200,
+        900,
+        2500,
+        400,
+        UINT16_MAX,
+        600,
+        800
+    );
+
+    expect_eq_u16("n2 pulse source", derived.n2_pulse_count, egs51_flip_uint16_t(1200));
+    expect_eq_u16("n3 pulse source", derived.n3_pulse_count, egs51_flip_uint16_t(900));
+    expect_eq_u16("engine speed flipped", derived.engine_speed, egs51_flip_uint16_t(2500));
+    expect_eq_u16("front-left valid encoded", derived.front_left_wheel_speed, egs51_flip_uint16_t(200));
+    expect_eq_u16("front-right invalid sentinel", derived.front_right_wheel_speed, 0xFFFF);
+    expect_eq_u16("rear-left valid encoded", derived.rear_left_wheel_speed, egs51_flip_uint16_t(300));
+    expect_eq_u16("rear-right valid encoded", derived.rear_right_wheel_speed, egs51_flip_uint16_t(400));
+}
+
+} // namespace
+
+int main() {
+    test_tcc_multi_is_full_byte_field();
+    test_tcc_multi_saturation();
+    test_torque_request_is_saturated();
+    test_freeze_logic_is_not_overwritten();
+    test_wheel_decode_tracks_valid_values();
+    test_engine_limp_inference_heuristic();
+    test_max_torque_factor_scaling();
+    test_rli31_mapping_uses_n3_and_validity();
+
+    if (g_failures == 0) {
+        std::cout << "PASS: host_egs51_bugfix_tests" << std::endl;
+        return 0;
+    }
+
+    std::cerr << "FAILED: host_egs51_bugfix_tests failures=" << g_failures << std::endl;
+    return 1;
+}

--- a/host_tests/test_lowlevel_logic.cpp
+++ b/host_tests/test_lowlevel_logic.cpp
@@ -1,0 +1,176 @@
+#include <cstdint>
+#include <iostream>
+#include <limits.h>
+
+#include "ioexpander_logic.h"
+#include "kickdownswitch_logic.h"
+#include "can_custom_logic.h"
+#include "sensors_logic.h"
+
+namespace {
+
+int g_failures = 0;
+
+void expect_true(const char* name, bool value) {
+    if (!value) {
+        std::cerr << "FAIL: " << name << " expected=true actual=false\n";
+        g_failures++;
+    }
+}
+
+void expect_false(const char* name, bool value) {
+    if (value) {
+        std::cerr << "FAIL: " << name << " expected=false actual=true\n";
+        g_failures++;
+    }
+}
+
+void expect_eq_u8(const char* name, uint8_t actual, uint8_t expected) {
+    if (actual != expected) {
+        std::cerr << "FAIL: " << name << " expected=" << (uint16_t)expected << " actual=" << (uint16_t)actual << "\n";
+        g_failures++;
+    }
+}
+
+void expect_eq_u16(const char* name, uint16_t actual, uint16_t expected) {
+    if (actual != expected) {
+        std::cerr << "FAIL: " << name << " expected=" << expected << " actual=" << actual << "\n";
+        g_failures++;
+    }
+}
+
+void expect_eq_i16(const char* name, int16_t actual, int16_t expected) {
+    if (actual != expected) {
+        std::cerr << "FAIL: " << name << " expected=" << expected << " actual=" << actual << "\n";
+        g_failures++;
+    }
+}
+
+void expect_eq_i32(const char* name, int actual, int expected) {
+    if (actual != expected) {
+        std::cerr << "FAIL: " << name << " expected=" << expected << " actual=" << actual << "\n";
+        g_failures++;
+    }
+}
+
+void test_ioexpander_bit_validation() {
+    expect_true("valid bit 0", ioexpander_is_valid_bit(0));
+    expect_true("valid bit 7", ioexpander_is_valid_bit(7));
+    expect_false("invalid bit -1", ioexpander_is_valid_bit(-1));
+    expect_false("invalid bit 8", ioexpander_is_valid_bit(8));
+}
+
+void test_ioexpander_bit_read_write() {
+    uint8_t input = 0x52; // 0b01010010
+    expect_true("bit1 true", ioexpander_get_input_bit(input, 1));
+    expect_true("bit4 true", ioexpander_get_input_bit(input, 4));
+    expect_false("bit0 false", ioexpander_get_input_bit(input, 0));
+    expect_false("invalid read returns false", ioexpander_get_input_bit(input, -1));
+
+    uint8_t out = 0;
+    out = ioexpander_set_output_bit(out, 2, true);
+    expect_eq_u8("set bit2", out, 0x04);
+    out = ioexpander_set_output_bit(out, 2, false);
+    expect_eq_u8("clear bit2", out, 0x00);
+
+    uint8_t unchanged = 0xAA;
+    expect_eq_u8("invalid set keeps state -1", ioexpander_set_output_bit(unchanged, -1, true), unchanged);
+    expect_eq_u8("invalid set keeps state 8", ioexpander_set_output_bit(unchanged, 8, false), unchanged);
+}
+
+void test_kickdown_rising_edge_only() {
+    expect_false("false->false", kickdown_is_new_press(false, false));
+    expect_true("false->true", kickdown_is_new_press(true, false));
+    expect_false("true->true", kickdown_is_new_press(true, true));
+    expect_false("true->false", kickdown_is_new_press(false, true));
+}
+
+void test_custom_can_coolant_and_kickdown_decode() {
+    ENGINE_100_CUSTOMCAN frame = {};
+    frame.T_COOLANT = 90;
+    frame.PEDAL = 200;
+    expect_eq_i16("coolant uses T_COOLANT", customcan_decode_engine_coolant(frame), 50);
+
+    frame.T_COOLANT = UINT8_MAX;
+    expect_eq_i16("coolant sna", customcan_decode_engine_coolant(frame), INT16_MAX);
+
+    frame.KD = true;
+    expect_true("kickdown true", customcan_decode_kickdown(frame));
+    frame.KD = false;
+    expect_false("kickdown false", customcan_decode_kickdown(frame));
+}
+
+void test_custom_can_torque_request_encoding() {
+    expect_eq_u16("torque req low clamp", customcan_encode_torque_request_nm(-1000.0f), 0);
+    expect_eq_u16("torque req nominal", customcan_encode_torque_request_nm(100.0f), 2400);
+    expect_eq_u16("torque req high clamp", customcan_encode_torque_request_nm(20000.0f), UINT16_MAX);
+}
+
+void test_custom_can_torque_request_control_bits() {
+    {
+        CustomCanTorqueRequestFields f = customcan_build_torque_request(TorqueRequestControlType::None, TorqueRequestBounds::LessThan, 120.0f);
+        expect_false("none ctrl0", f.ctrl0);
+        expect_false("none ctrl1", f.ctrl1);
+        expect_false("none min", f.min);
+        expect_false("none max", f.max);
+        expect_eq_u16("none raw", f.raw_torque, 0);
+    }
+    {
+        CustomCanTorqueRequestFields f = customcan_build_torque_request(TorqueRequestControlType::NormalSpeed, TorqueRequestBounds::LessThan, 100.0f);
+        expect_true("normal ctrl0", f.ctrl0);
+        expect_false("normal ctrl1", f.ctrl1);
+        expect_true("normal min", f.min);
+        expect_false("normal max", f.max);
+        expect_eq_u16("normal raw", f.raw_torque, 2400);
+    }
+    {
+        CustomCanTorqueRequestFields f = customcan_build_torque_request(TorqueRequestControlType::FastAsPossible, TorqueRequestBounds::MoreThan, 100.0f);
+        expect_false("fast ctrl0", f.ctrl0);
+        expect_true("fast ctrl1", f.ctrl1);
+        expect_false("fast min", f.min);
+        expect_true("fast max", f.max);
+        expect_eq_u16("fast raw", f.raw_torque, 2400);
+    }
+    {
+        CustomCanTorqueRequestFields f = customcan_build_torque_request(TorqueRequestControlType::BackToDemandTorque, TorqueRequestBounds::Exact, 20000.0f);
+        expect_true("back ctrl0", f.ctrl0);
+        expect_true("back ctrl1", f.ctrl1);
+        expect_true("back min", f.min);
+        expect_true("back max", f.max);
+        expect_eq_u16("back raw saturated", f.raw_torque, UINT16_MAX);
+    }
+}
+
+void test_atf_resistance_guard() {
+    int resistance = -1;
+    expect_true("valid divider", sensors_try_calc_atf_resistance(1650, 2000, &resistance));
+    expect_eq_i32("valid divider result", resistance, 2000);
+
+    resistance = -1;
+    expect_true("zero input is valid", sensors_try_calc_atf_resistance(0, 2000, &resistance));
+    expect_eq_i32("zero input resistance", resistance, 0);
+
+    expect_false("3300mv is invalid", sensors_try_calc_atf_resistance(3300, 2000, &resistance));
+    expect_false("above rail invalid", sensors_try_calc_atf_resistance(3400, 2000, &resistance));
+    expect_false("null output ptr", sensors_try_calc_atf_resistance(1000, 2000, nullptr));
+}
+
+} // namespace
+
+int main() {
+    test_ioexpander_bit_validation();
+    test_ioexpander_bit_read_write();
+    test_kickdown_rising_edge_only();
+    test_custom_can_coolant_and_kickdown_decode();
+    test_custom_can_torque_request_encoding();
+    test_custom_can_torque_request_control_bits();
+    test_atf_resistance_guard();
+
+    if (g_failures == 0) {
+        std::cout << "PASS: host_lowlevel_logic_tests" << std::endl;
+        return 0;
+    }
+
+    std::cerr << "FAILED: host_lowlevel_logic_tests failures=" << g_failures << std::endl;
+    return 1;
+}

--- a/host_tests/test_tcu_maths.cpp
+++ b/host_tests/test_tcu_maths.cpp
@@ -1,0 +1,89 @@
+#include <cmath>
+#include <cstdint>
+#include <iostream>
+
+#include "tcu_maths.h"
+
+namespace {
+
+int g_failures = 0;
+
+void expect_eq_i32(const char* name, int32_t actual, int32_t expected) {
+    if (actual != expected) {
+        std::cerr << "FAIL: " << name << " expected=" << expected << " actual=" << actual << "\n";
+        g_failures++;
+    }
+}
+
+void expect_eq_i16(const char* name, int16_t actual, int16_t expected) {
+    if (actual != expected) {
+        std::cerr << "FAIL: " << name << " expected=" << expected << " actual=" << actual << "\n";
+        g_failures++;
+    }
+}
+
+void expect_near_f(const char* name, float actual, float expected, float eps = 0.001f) {
+    if (std::fabs(actual - expected) > eps) {
+        std::cerr << "FAIL: " << name << " expected=" << expected << " actual=" << actual << "\n";
+        g_failures++;
+    }
+}
+
+void test_interpolate_float_linear() {
+    expect_near_f("interpolate linear midpoint", interpolate_float(50.0f, 0.0f, 100.0f, 0.0f, 100.0f, InterpType::Linear), 50.0f);
+    expect_near_f("interpolate linear low clamp", interpolate_float(-5.0f, 10.0f, 20.0f, 0.0f, 100.0f, InterpType::Linear), 10.0f);
+    expect_near_f("interpolate linear high clamp", interpolate_float(150.0f, 10.0f, 20.0f, 0.0f, 100.0f, InterpType::Linear), 20.0f);
+}
+
+void test_interpolate_float_inverted_axis() {
+    // Function swaps ranges when raw bounds are inverted.
+    expect_near_f("interpolate inverted range", interpolate_float(75.0f, 100.0f, 0.0f, 100.0f, 0.0f, InterpType::Linear), 75.0f);
+}
+
+void test_interpolate_int() {
+    expect_eq_i32("interpolate int midpoint", interpolate_int(50, 0, 100, 0, 100), 50);
+    expect_eq_i32("interpolate int low clamp", interpolate_int(-100, 0, 100, 0, 100), 0);
+    expect_eq_i32("interpolate int high clamp", interpolate_int(200, 0, 100, 0, 100), 100);
+}
+
+void test_first_order_filter() {
+    // (new + n*last)/(n+1)
+    expect_eq_i32("fof int basic", first_order_filter(3, 100, 0), 25);
+    expect_eq_i32("fof int previous weight", first_order_filter(3, 0, 100), 75);
+    expect_near_f("fof float basic", first_order_filter_f(3, 100, 0.0f), 25.0f);
+
+    // Guard path for 0xFF -> 0xFE.
+    expect_eq_i32("fof int sample_count guard", first_order_filter(0xFF, 255, 0), 1);
+    expect_near_f("fof float sample_count guard", first_order_filter_f(0xFF, 255, 0.0f), 1.0f);
+}
+
+void test_linear_ramp_with_timer() {
+    expect_eq_i32("linear ramp up", linear_ramp_with_timer(0, 100, 4), 25);
+    expect_eq_i32("linear ramp down", linear_ramp_with_timer(100, 0, 4), 75);
+    expect_eq_i32("linear ramp timer zero", linear_ramp_with_timer(0, 100, 0), 100);
+}
+
+void test_linear_interp_with_percentage() {
+    expect_eq_i16("lin interp 0%", linear_interp_with_percentage(0, 100, 50), 50);
+    expect_eq_i16("lin interp 100%", linear_interp_with_percentage(100, 100, 50), 100);
+    expect_eq_i16("lin interp 50%", linear_interp_with_percentage(50, 100, 0), 50);
+}
+
+} // namespace
+
+int main() {
+    test_interpolate_float_linear();
+    test_interpolate_float_inverted_axis();
+    test_interpolate_int();
+    test_first_order_filter();
+    test_linear_ramp_with_timer();
+    test_linear_interp_with_percentage();
+
+    if (g_failures == 0) {
+        std::cout << "PASS: host_math_tests" << std::endl;
+        return 0;
+    }
+
+    std::cerr << "FAILED: host_math_tests failures=" << g_failures << std::endl;
+    return 1;
+}

--- a/lib/core/tcu_maths.cpp
+++ b/lib/core/tcu_maths.cpp
@@ -1,5 +1,9 @@
 #include "tcu_maths.h"
 
+float scale_number(float raw, float new_min, float new_max, float raw_min, float raw_max) {
+    return interpolate_float(raw, new_min, new_max, raw_min, raw_max, InterpType::Linear);
+}
+
 float interpolate_float(float raw, float new_min, float new_max, float raw_min, float raw_max, InterpType interp_type) {
     // Short cuts for cases where we are > or < than bounds
     float ret;

--- a/lib/egs51_ecus/can_data.txt
+++ b/lib/egs51_ecus/can_data.txt
@@ -196,7 +196,7 @@ ECU GS51
 		SIGNAL KICKDOWN, OFFSET: 30, LEN: 1, DESC: Kickdown pressed, DATA TYPE BOOL
 		SIGNAL FWD, OFFSET: 31, LEN: 1, DESC: Front wheel drive, DATA TYPE BOOL
 		# 5th byte
-		SIGNAL TCC_MULTI, OFFSET: 32, LEN: 8, DESC: TCC Torque multiplier, DATA TYPE BOOL
+		SIGNAL TCC_MULTI, OFFSET: 32, LEN: 8, DESC: TCC Torque multiplier, DATA TYPE NUMBER(_MULTIPLIER_: 1.0, _OFFSET_: 0.0)
 		# 6th byte
 		SIGNAL FEHLER, OFFSET: 44, LEN: 4, DESC: error number or counter for calid / CVN transmission, DATA TYPE NUMBER(_MULTIPLIER_: 1.0, _OFFSET_: 0.0)
 ECU EWM51

--- a/lib/egs51_ecus/src/GS51.h
+++ b/lib/egs51_ecus/src/GS51.h
@@ -56,7 +56,7 @@ typedef union {
 		 /** BITFIELD PADDING. DO NOT CHANGE **/
 		uint8_t __PADDING2__: 4;
 		/** TCC Torque multiplier **/
-		bool TCC_MULTI: 8;
+		uint8_t TCC_MULTI: 8;
 		/** Front wheel drive **/
 		bool FWD: 1;
 		/** Kickdown pressed **/

--- a/src/adaptation/shift_adaptation.h
+++ b/src/adaptation/shift_adaptation.h
@@ -9,6 +9,8 @@
 class ShiftAdaptationSystem  {
 public:
     ShiftAdaptationSystem();
+    ShiftAdaptationSystem(const ShiftAdaptationSystem&) = delete;
+    ShiftAdaptationSystem& operator=(const ShiftAdaptationSystem&) = delete;
     void init_shift();
     void update();
     int8_t get_prefill_cycles_offset(uint8_t shift_idx);

--- a/src/canbus/can_custom.cpp
+++ b/src/canbus/can_custom.cpp
@@ -6,6 +6,7 @@
 #include "nvs/eeprom_config.h"
 #include "shifter/shifter_trrs.h"
 #include "shifter/shifter_ewm.h"
+#include "can_custom_logic.h"
 
 CustomCan::CustomCan(const char *name, uint8_t tx_time_ms, uint32_t baud, Shifter *shifter) : EgsBaseCan(name, tx_time_ms, baud, shifter) 
 {
@@ -58,6 +59,10 @@ bool CustomCan::get_engine_is_limp(const uint32_t expire_time_ms) { // TODO
 }
 
 bool CustomCan::get_kickdown(const uint32_t expire_time_ms) { // TODO
+    ENGINE_100_CUSTOMCAN engine_data{};
+    if (this->engine.get_ENGINE_100(GET_CLOCK_TIME(), expire_time_ms, &engine_data)) {
+        return customcan_decode_kickdown(engine_data);
+    }
     return false;
 }
 
@@ -97,13 +102,10 @@ PaddlePosition CustomCan::get_paddle_position(const uint32_t expire_time_ms) {
 
 int16_t CustomCan::get_engine_coolant_temp(const uint32_t expire_time_ms) {
     ENGINE_100_CUSTOMCAN engine_data{};
-    int16_t ret = INT16_MAX;
     if (this->engine.get_ENGINE_100(GET_CLOCK_TIME(), expire_time_ms, &engine_data)) {
-        if (engine_data.T_COOLANT != UINT8_MAX) {
-            ret = (int16_t)engine_data.PEDAL - 40;
-        }
+        return customcan_decode_engine_coolant(engine_data);
     }
-    return ret;
+    return INT16_MAX;
 }
 
 int16_t CustomCan::get_engine_oil_temp(const uint32_t expire_time_ms) {
@@ -230,6 +232,7 @@ void CustomCan::set_gearbox_temperature(int16_t temp) {
 }
 
 void CustomCan::set_input_shaft_speed(uint16_t rpm) {
+    this->tx_400.INPUT_RPM = rpm;
 }
 
 void CustomCan::set_is_all_wheel_drive(bool is_4wd) {
@@ -246,36 +249,12 @@ void CustomCan::set_gearbox_ok(bool is_ok) {
 }
 
 void CustomCan::set_torque_request(TorqueRequestControlType control_type, TorqueRequestBounds limit_type, float amount_nm) {
-    if (control_type == TorqueRequestControlType::None) {
-        tx_410.TRQ_REQ_CTRL0 = false;
-        tx_410.TRQ_REQ_CTRL1 = false;
-    } else if (control_type == TorqueRequestControlType::FastAsPossible) {
-        tx_410.TRQ_REQ_CTRL0 = false;
-        tx_410.TRQ_REQ_CTRL1 = true;
-    } else if (control_type == TorqueRequestControlType::BackToDemandTorque) {
-        tx_410.TRQ_REQ_CTRL0 = true;
-        tx_410.TRQ_REQ_CTRL1 = true;
-    } else { // Normal speed
-        tx_410.TRQ_REQ_CTRL0 = true;
-        tx_410.TRQ_REQ_CTRL1 = false;
-    }
-    if (control_type != TorqueRequestControlType::None) {
-        tx_410.TRQ_REQ_TRQ = (amount_nm + 500) * 4;
-        if (limit_type == TorqueRequestBounds::LessThan) {
-            tx_410.TRQ_REQ_MIN = true;
-            tx_410.TRQ_REQ_MAX = false;
-        } else if (limit_type == TorqueRequestBounds::MoreThan) {
-            tx_410.TRQ_REQ_MIN = false;
-            tx_410.TRQ_REQ_MAX = true;
-        } else {
-            tx_410.TRQ_REQ_MIN = true;
-            tx_410.TRQ_REQ_MAX = true;
-        }
-    } else {
-        tx_410.TRQ_REQ_MIN = false;
-        tx_410.TRQ_REQ_MAX = false;
-        tx_410.TRQ_REQ_TRQ = 0;
-    }
+    CustomCanTorqueRequestFields fields = customcan_build_torque_request(control_type, limit_type, amount_nm);
+    tx_410.TRQ_REQ_CTRL0 = fields.ctrl0;
+    tx_410.TRQ_REQ_CTRL1 = fields.ctrl1;
+    tx_410.TRQ_REQ_MIN = fields.min;
+    tx_410.TRQ_REQ_MAX = fields.max;
+    tx_410.TRQ_REQ_TRQ = fields.raw_torque;
 }
 
 void CustomCan::set_garage_shift_state(bool enable, bool to_d) {

--- a/src/canbus/can_custom_logic.cpp
+++ b/src/canbus/can_custom_logic.cpp
@@ -1,0 +1,71 @@
+#include "can_custom_logic.h"
+
+#include <limits.h>
+
+int16_t customcan_decode_engine_coolant(const ENGINE_100_CUSTOMCAN& frame) {
+    if (frame.T_COOLANT == UINT8_MAX) {
+        return INT16_MAX;
+    }
+    return (int16_t)frame.T_COOLANT - 40;
+}
+
+bool customcan_decode_kickdown(const ENGINE_100_CUSTOMCAN& frame) {
+    return frame.KD;
+}
+
+uint16_t customcan_encode_torque_request_nm(float amount_nm) {
+    float raw_f = (amount_nm + 500.0f) * 4.0f;
+    if (raw_f <= 0.0f) {
+        return 0;
+    }
+    if (raw_f >= 65535.0f) {
+        return UINT16_MAX;
+    }
+    return (uint16_t)raw_f;
+}
+
+CustomCanTorqueRequestFields customcan_build_torque_request(TorqueRequestControlType control_type, TorqueRequestBounds limit_type, float amount_nm) {
+    CustomCanTorqueRequestFields fields = {
+        .ctrl0 = false,
+        .ctrl1 = false,
+        .min = false,
+        .max = false,
+        .raw_torque = 0,
+    };
+
+    switch (control_type) {
+        case TorqueRequestControlType::FastAsPossible:
+            fields.ctrl0 = false;
+            fields.ctrl1 = true;
+            break;
+        case TorqueRequestControlType::BackToDemandTorque:
+            fields.ctrl0 = true;
+            fields.ctrl1 = true;
+            break;
+        case TorqueRequestControlType::NormalSpeed:
+            fields.ctrl0 = true;
+            fields.ctrl1 = false;
+            break;
+        case TorqueRequestControlType::None:
+        default:
+            fields.ctrl0 = false;
+            fields.ctrl1 = false;
+            break;
+    }
+
+    if (control_type != TorqueRequestControlType::None) {
+        fields.raw_torque = customcan_encode_torque_request_nm(amount_nm);
+        if (limit_type == TorqueRequestBounds::LessThan) {
+            fields.min = true;
+            fields.max = false;
+        } else if (limit_type == TorqueRequestBounds::MoreThan) {
+            fields.min = false;
+            fields.max = true;
+        } else {
+            fields.min = true;
+            fields.max = true;
+        }
+    }
+
+    return fields;
+}

--- a/src/canbus/can_custom_logic.h
+++ b/src/canbus/can_custom_logic.h
@@ -1,0 +1,21 @@
+#ifndef CAN_CUSTOM_LOGIC_H
+#define CAN_CUSTOM_LOGIC_H
+
+#include <stdint.h>
+#include "../../lib/customcan_ecus/src/ENGINE.h"
+#include "can_defines.h"
+
+struct CustomCanTorqueRequestFields {
+	bool ctrl0;
+	bool ctrl1;
+	bool min;
+	bool max;
+	uint16_t raw_torque;
+};
+
+int16_t customcan_decode_engine_coolant(const ENGINE_100_CUSTOMCAN& frame);
+bool customcan_decode_kickdown(const ENGINE_100_CUSTOMCAN& frame);
+uint16_t customcan_encode_torque_request_nm(float amount_nm);
+CustomCanTorqueRequestFields customcan_build_torque_request(TorqueRequestControlType control_type, TorqueRequestBounds limit_type, float amount_nm);
+
+#endif

--- a/src/canbus/can_egs51.cpp
+++ b/src/canbus/can_egs51.cpp
@@ -6,6 +6,7 @@
 #include "nvs/eeprom_config.h"
 #include "shifter/shifter_trrs.h"
 #include "shifter/shifter_ewm.h"
+#include "can_egs51_logic.h"
 
 Egs51Can::Egs51Can(const char *name, uint8_t tx_time_ms, uint32_t baud, Shifter *shifter) : EgsBaseCan(name, tx_time_ms, baud, shifter) 
 {
@@ -18,10 +19,18 @@ Egs51Can::Egs51Can(const char *name, uint8_t tx_time_ms, uint32_t baud, Shifter 
 
 uint16_t Egs51Can::get_front_right_wheel(const uint32_t expire_time_ms)
 {
-	return UINT16_MAX;
+    BS_200_EGS51 bs200;
+    if (this->esp51.get_BS_200(GET_CLOCK_TIME(), expire_time_ms, &bs200)) {
+        return egs51_decode_wheel_speed_or_sna(bs200.DVR);
+    }
+    return UINT16_MAX;
 }
 
 uint16_t Egs51Can::get_front_left_wheel(const uint32_t expire_time_ms) {
+    BS_200_EGS51 bs200;
+    if (this->esp51.get_BS_200(GET_CLOCK_TIME(), expire_time_ms, &bs200)) {
+        return egs51_decode_wheel_speed_or_sna(bs200.DVL);
+    }
     return UINT16_MAX;
 }
 
@@ -54,20 +63,24 @@ EngineType Egs51Can::get_engine_type(const uint32_t expire_time_ms) {
 }
 
 bool Egs51Can::get_engine_is_limp(const uint32_t expire_time_ms) { // TODO
+    MS_308_EGS51 ms308;
+    if (this->ms51.get_MS_308(GET_CLOCK_TIME(), expire_time_ms, &ms308)) {
+        return egs51_infer_engine_limp(ms308.TEMP_KL, ms308.UEHITZ, ms308.DIAG_KL);
+    }
     return false;
 }
 
 bool Egs51Can::get_kickdown(const uint32_t expire_time_ms) {
     bool ret  = false;
     // Only for the CAN shifter
-    EWM_230_EGS52 dest;
+    EWM_230_EGS51 dest;
 	if (this->ewm.get_EWM_230(GET_CLOCK_TIME(), expire_time_ms, &dest)){
         ret  = dest.KD;
     }
     return ret;
 }
 
-uint8_t Egs51Can::get_pedal_value(const uint32_t expire_time_ms) { // TODO
+uint8_t Egs51Can::get_pedal_value(const uint32_t expire_time_ms) {
     MS_210_EGS51 ms210;
     if (this->ms51.get_MS_210(GET_CLOCK_TIME(), expire_time_ms, &ms210)) {
         return ms210.PW;
@@ -91,7 +104,7 @@ CanTorqueData Egs51Can::get_torque_data(const uint32_t expire_time_ms) {
         }
         if (UINT8_MAX != ms310.MAX_TORQUE) {
             ret.m_max = ((int16_t)ms310.MAX_TORQUE)*3;
-            // TODO -> ms310.MAX_TRQ_FACTOR
+            ret.m_max = egs51_apply_max_torque_factor(ret.m_max, ms310.MAX_TRQ_FACTOR);
         }
         if (UINT8_MAX != ms210.M_ESP) {
             m_esp = ((int16_t)ms210.M_ESP)*3;
@@ -117,14 +130,15 @@ CanTorqueData Egs51Can::get_torque_data(const uint32_t expire_time_ms) {
         }
 
         bool freeze = this->gs218.TORQUE_REQ_EN;
-        // Change torque values based on freezing or not
-        if (freeze) {
-            ret.m_converted_driver = MAX(driver_converted - this->req_static_torque_delta, static_converted);
-        } else {
-            this->req_static_torque_delta = driver_converted - static_converted;
-        }
-
-        ret.m_converted_driver = driver_converted;
+        Egs51FreezeResult freeze_result = egs51_apply_freeze_logic(
+            freeze,
+            driver_converted,
+            static_converted,
+            this->req_static_torque_delta
+        );
+        // Preserve freeze-adjusted driver torque instead of overwriting it later.
+        ret.m_converted_driver = freeze_result.driver_converted;
+        this->req_static_torque_delta = freeze_result.req_static_torque_delta;
         ret.m_converted_static = static_converted;
     }
     return ret;
@@ -176,16 +190,36 @@ uint16_t Egs51Can::get_engine_rpm(const uint32_t expire_time_ms) {
     }
 }
 
-bool Egs51Can::get_is_starting(const uint32_t expire_time_ms) { // TODO
+bool Egs51Can::get_is_starting(const uint32_t expire_time_ms) {
+    MS_308_EGS51 ms308;
+    if (this->ms51.get_MS_308(GET_CLOCK_TIME(), expire_time_ms, &ms308)) {
+        return ms308.ANL_LFT;
+    }
     return false;
 }
 
 bool Egs51Can::get_is_brake_pressed(const uint32_t expire_time_ms) {
+    BS_200_EGS51 bs200;
+    if (this->esp51.get_BS_200(GET_CLOCK_TIME(), expire_time_ms, &bs200)) {
+        return bs200.BLS == BS_200h_BLS_EGS51::BREMSE_BET;
+    }
     return false;
 }
 
 bool Egs51Can::get_profile_btn_press(const uint32_t expire_time_ms) {
+    EWM_230_EGS51 ewm_data;
+    if (this->ewm.get_EWM_230(GET_CLOCK_TIME(), expire_time_ms, &ewm_data)) {
+        return ewm_data.FPT;
+    }
     return false;
+}
+
+ProfileSwitchPos Egs51Can::get_profile_switch_pos(const uint32_t expire_time_ms) {
+    EWM_230_EGS51 ewm_data;
+    if (this->ewm.get_EWM_230(GET_CLOCK_TIME(), expire_time_ms, &ewm_data)) {
+        return ewm_data.W_S ? ProfileSwitchPos::Top : ProfileSwitchPos::Bottom;
+    }
+    return ProfileSwitchPos::SNV;
 }
 
 uint16_t Egs51Can::get_fuel_flow_rate(const uint32_t expire_time_ms) {
@@ -303,39 +337,39 @@ void Egs51Can::set_target_gear(GearboxGear target) {
 
 ShifterPosition Egs51Can::internal_can_shifter_get_shifter_position(const uint32_t expire_time_ms) {
 	ShifterPosition ret = ShifterPosition::SignalNotAvailable;
-	EWM_230_EGS52 dest;
+    EWM_230_EGS51 dest;
 	if (this->ewm.get_EWM_230(GET_CLOCK_TIME(), expire_time_ms, &dest))
 	{
 		switch (dest.WHC)
 		{
-		case EWM_230h_WHC_EGS52::D:
+        case EWM_230h_WHC_EGS51::D:
 			ret = ShifterPosition::D;
 			break;
-		case EWM_230h_WHC_EGS52::N:
+        case EWM_230h_WHC_EGS51::N:
 			ret = ShifterPosition::N;
 			break;
-		case EWM_230h_WHC_EGS52::R:
+        case EWM_230h_WHC_EGS51::R:
 			ret = ShifterPosition::R;
 			break;
-		case EWM_230h_WHC_EGS52::P:
+        case EWM_230h_WHC_EGS51::P:
 			ret = ShifterPosition::P;
 			break;
-		case EWM_230h_WHC_EGS52::PLUS:
+        case EWM_230h_WHC_EGS51::PLUS:
 			ret = ShifterPosition::PLUS;
 			break;
-		case EWM_230h_WHC_EGS52::MINUS:
+        case EWM_230h_WHC_EGS51::MINUS:
 			ret = ShifterPosition::MINUS;
 			break;
-		case EWM_230h_WHC_EGS52::N_ZW_D:
+        case EWM_230h_WHC_EGS51::N_ZW_D:
 			ret = ShifterPosition::N_D;
 			break;
-		case EWM_230h_WHC_EGS52::R_ZW_N:
+        case EWM_230h_WHC_EGS51::R_ZW_N:
 			ret = ShifterPosition::R_N;
 			break;
-		case EWM_230h_WHC_EGS52::P_ZW_R:
+        case EWM_230h_WHC_EGS51::P_ZW_R:
 			ret = ShifterPosition::P_R;
 			break;
-		case EWM_230h_WHC_EGS52::SNV:
+        case EWM_230h_WHC_EGS51::SNV:
 			break;
 		default:
 			break;
@@ -351,6 +385,7 @@ void Egs51Can::set_input_shaft_speed(uint16_t rpm) {
 }
 
 void Egs51Can::set_is_all_wheel_drive(bool is_4wd) {
+    this->gs218.FWD = !is_4wd;
 }
 
 void Egs51Can::set_wheel_torque(uint16_t t) {
@@ -370,6 +405,7 @@ void Egs51Can::set_gearbox_ok(bool is_ok) {
 }
 
 void Egs51Can::set_torque_request(TorqueRequestControlType control_type, TorqueRequestBounds limit_type, float amount_nm) {
+    (void)limit_type;
     if (control_type == TorqueRequestControlType::None) {
         this->gs218.TORQUE_REQ_EN = false;
         this->gs218.SE = false;
@@ -378,11 +414,12 @@ void Egs51Can::set_torque_request(TorqueRequestControlType control_type, TorqueR
         // Just enable the request
         this->gs218.TORQUE_REQ_EN = true;
         this->gs218.SE = true;
-        this->gs218.TORQUE_REQ = amount_nm/3;
+        this->gs218.TORQUE_REQ = egs51_torque_request_to_raw(amount_nm);
     }
 }
 
 void Egs51Can::set_garage_shift_state(bool enable, bool to_d) {
+    (void)to_d;
     this->gs218.GARAGE_SHIFT = enable;
 }
 
@@ -413,8 +450,7 @@ void Egs51Can::set_safe_start(bool can_start) {
 }
 
 void Egs51Can::set_tcc_trq_multiplier(float multi) {
-    float clamped = MAX(100, MIN(254, multi*100));
-    gs218.TCC_MULTI = (uint8_t)clamped;
+    gs218.TCC_MULTI = egs51_tcc_multiplier_to_raw(multi);
 }
 
 void Egs51Can::tx_frames() {
@@ -423,6 +459,7 @@ void Egs51Can::tx_frames() {
     // Copy current CAN frame values to here so we don't
     // accidentally modify parity calculations
     gs_218tx = {gs218.raw};
+    gs_218tx.KICKDOWN = get_kickdown(300);
     // Now set CVN Counter (Increases every frame)
     gs_218tx.FEHLER = cvn_counter;
     cvn_counter++;

--- a/src/canbus/can_egs51.h
+++ b/src/canbus/can_egs51.h
@@ -4,7 +4,7 @@
 #include "../../egs51_ecus/src/GS51.h"
 #include "../../egs51_ecus/src/MS51.h"
 #include "../../egs51_ecus/src/ESP51.h"
-#include "../../egs52_ecus/src/EWM.h"
+#include "../../egs51_ecus/src/EWM51.h"
 #include "shifter/shifter.h"
 
 class Egs51Can: public EgsBaseCan {
@@ -48,6 +48,7 @@ class Egs51Can: public EgsBaseCan {
         // Returns true if engine is cranking
         bool get_is_starting(const uint32_t expire_time_ms) override;
         bool get_profile_btn_press(const uint32_t expire_time_ms) override;
+        ProfileSwitchPos get_profile_switch_pos(const uint32_t expire_time_ms) override;
         uint16_t get_fuel_flow_rate(const uint32_t expire_time_ms) override;
         // 
         bool get_is_brake_pressed(const uint32_t expire_time_ms) override;
@@ -97,7 +98,7 @@ class Egs51Can: public EgsBaseCan {
         // CAN Frames to Tx
         GS_218_EGS51 gs218 = {0};
         ECU_MS51 ms51 = ECU_MS51();
-        ECU_EWM ewm = ECU_EWM();        
+        ECU_EWM51 ewm = ECU_EWM51();        
         ECU_ESP51 esp51 = ECU_ESP51();
         uint8_t cvn_counter = 0; 
         int16_t req_static_torque_delta = 0;

--- a/src/canbus/can_egs51_logic.cpp
+++ b/src/canbus/can_egs51_logic.cpp
@@ -1,0 +1,76 @@
+#include "can_egs51_logic.h"
+
+#include <limits.h>
+
+uint8_t egs51_torque_request_to_raw(float amount_nm) {
+    float scaled = amount_nm / 3.0f;
+    if (scaled < 0.0f) {
+        return 0;
+    }
+    if (scaled > 253.0f) {
+        // 0xFE is reserved as "request inactive" in GS_218.
+        return 0xFD;
+    }
+    return (uint8_t)scaled;
+}
+
+Egs51FreezeResult egs51_apply_freeze_logic(bool freeze, int16_t driver_converted, int16_t static_converted, int16_t req_static_torque_delta) {
+    Egs51FreezeResult result = {
+        .driver_converted = driver_converted,
+        .req_static_torque_delta = req_static_torque_delta,
+    };
+
+    if (freeze) {
+        int16_t frozen = driver_converted - req_static_torque_delta;
+        if (frozen < static_converted) {
+            frozen = static_converted;
+        }
+        result.driver_converted = frozen;
+    } else {
+        result.req_static_torque_delta = driver_converted - static_converted;
+    }
+    return result;
+}
+
+uint8_t egs51_tcc_multiplier_to_raw(float multi) {
+    float raw = multi * 100.0f;
+    if (raw < 100.0f) {
+        raw = 100.0f;
+    }
+    if (raw > 254.0f) {
+        raw = 254.0f;
+    }
+    return (uint8_t)raw;
+}
+
+uint16_t egs51_decode_wheel_speed_or_sna(uint16_t wheel_raw) {
+    // ESP51 uses 0x3FFF as wheel-speed signal-not-available sentinel.
+    if (wheel_raw == 0x3FFF) {
+        return UINT16_MAX;
+    }
+    return wheel_raw;
+}
+
+bool egs51_infer_engine_limp(bool temp_kl, bool uehitz, bool diag_kl) {
+    // Conservative fallback heuristic until a direct limp-status source is decoded.
+    // Avoid using DIAG lamp alone to prevent false limp classification from generic MIL events.
+    return uehitz || (temp_kl && diag_kl);
+}
+
+int16_t egs51_apply_max_torque_factor(int16_t base_max_nm, uint8_t max_trq_factor_raw) {
+    // 0xFF means value unavailable in this protocol family.
+    if (base_max_nm == INT16_MAX || max_trq_factor_raw == UINT8_MAX) {
+        return base_max_nm;
+    }
+
+    // Same style as other families: factor uses approx 1/128 scaling.
+    float factor = (float)max_trq_factor_raw * 0.0078f;
+    int32_t scaled = (int32_t)((float)base_max_nm * factor);
+    if (scaled > INT16_MAX) {
+        return INT16_MAX;
+    }
+    if (scaled < INT16_MIN) {
+        return INT16_MIN;
+    }
+    return (int16_t)scaled;
+}

--- a/src/canbus/can_egs51_logic.h
+++ b/src/canbus/can_egs51_logic.h
@@ -1,0 +1,18 @@
+#ifndef CAN_EGS51_LOGIC_H
+#define CAN_EGS51_LOGIC_H
+
+#include <stdint.h>
+
+struct Egs51FreezeResult {
+    int16_t driver_converted;
+    int16_t req_static_torque_delta;
+};
+
+uint8_t egs51_torque_request_to_raw(float amount_nm);
+Egs51FreezeResult egs51_apply_freeze_logic(bool freeze, int16_t driver_converted, int16_t static_converted, int16_t req_static_torque_delta);
+uint8_t egs51_tcc_multiplier_to_raw(float multi);
+uint16_t egs51_decode_wheel_speed_or_sna(uint16_t wheel_raw);
+bool egs51_infer_engine_limp(bool temp_kl, bool uehitz, bool diag_kl);
+int16_t egs51_apply_max_torque_factor(int16_t base_max_nm, uint8_t max_trq_factor_raw);
+
+#endif // CAN_EGS51_LOGIC_H

--- a/src/canbus/can_egs53.cpp
+++ b/src/canbus/can_egs53.cpp
@@ -172,7 +172,7 @@ CanTorqueData Egs53Can::get_torque_data(const uint32_t expire_time_ms) {
         int indicated = 0;
         // Calculate converted torque from ESP
         // Chrysler cars don't seem to report MAX/MIN
-        if (INT_MAX != ret.m_max && INT_MAX != ret.m_min) {
+        if (INT16_MAX != ret.m_max && INT16_MAX != ret.m_min) {
             tmp = MIN(esp, ret.m_max);
         }
         if (tmp <= 0) {

--- a/src/diag/egs_emulation_logic.cpp
+++ b/src/diag/egs_emulation_logic.cpp
@@ -1,0 +1,26 @@
+#include "egs_emulation_logic.h"
+
+#include <limits.h>
+
+uint16_t egs51_flip_uint16_t(uint16_t x) {
+    return ((x & 0xff) << 8) | ((x & 0xff00) >> 8);
+}
+
+static uint16_t encode_wheel_speed(uint16_t wheel_speed) {
+    if (UINT16_MAX == wheel_speed) {
+        return 0xFFFF;
+    }
+    return egs51_flip_uint16_t((uint16_t)(wheel_speed / 2));
+}
+
+Egs51Rli31DerivedData egs51_build_rli31_derived(uint16_t n2, uint16_t n3, uint16_t engine_rpm, uint16_t front_left_wheel, uint16_t front_right_wheel, uint16_t rear_left_wheel, uint16_t rear_right_wheel) {
+    Egs51Rli31DerivedData derived = {};
+    derived.n2_pulse_count = egs51_flip_uint16_t(n2);
+    derived.n3_pulse_count = egs51_flip_uint16_t(n3);
+    derived.engine_speed = egs51_flip_uint16_t(engine_rpm);
+    derived.front_left_wheel_speed = encode_wheel_speed(front_left_wheel);
+    derived.front_right_wheel_speed = encode_wheel_speed(front_right_wheel);
+    derived.rear_left_wheel_speed = encode_wheel_speed(rear_left_wheel);
+    derived.rear_right_wheel_speed = encode_wheel_speed(rear_right_wheel);
+    return derived;
+}

--- a/src/diag/egs_emulation_logic.h
+++ b/src/diag/egs_emulation_logic.h
@@ -1,0 +1,19 @@
+#ifndef EGS_EMULATION_LOGIC_H
+#define EGS_EMULATION_LOGIC_H
+
+#include <stdint.h>
+
+struct Egs51Rli31DerivedData {
+    uint16_t n2_pulse_count;
+    uint16_t n3_pulse_count;
+    uint16_t engine_speed;
+    uint16_t front_left_wheel_speed;
+    uint16_t front_right_wheel_speed;
+    uint16_t rear_left_wheel_speed;
+    uint16_t rear_right_wheel_speed;
+};
+
+uint16_t egs51_flip_uint16_t(uint16_t x);
+Egs51Rli31DerivedData egs51_build_rli31_derived(uint16_t n2, uint16_t n3, uint16_t engine_rpm, uint16_t front_left_wheel, uint16_t front_right_wheel, uint16_t rear_left_wheel, uint16_t rear_right_wheel);
+
+#endif // EGS_EMULATION_LOGIC_H

--- a/src/diag/kwp2000.h
+++ b/src/diag/kwp2000.h
@@ -29,6 +29,8 @@ class Kwp2000_server {
     public:
         Kwp2000_server(EgsBaseCan* can_layer, Gearbox* gearbox);
         ~Kwp2000_server();
+        Kwp2000_server(const Kwp2000_server&) = delete;
+        Kwp2000_server& operator=(const Kwp2000_server&) = delete;
 
         static void start_kwp_server(void *_this) {
             static_cast<Kwp2000_server*>(_this)->server_loop();

--- a/src/gearbox.h
+++ b/src/gearbox.h
@@ -31,6 +31,8 @@ struct PostShiftTorqueRamp {
 class Gearbox {
 public:
     explicit Gearbox(Shifter* shifter);
+    Gearbox(const Gearbox&) = delete;
+    Gearbox& operator=(const Gearbox&) = delete;
     // Diag test
     ClutchSpeeds diag_get_clutch_speeds();
     void set_profile(AbstractProfile* prof);

--- a/src/inputcomponents/kickdownswitch.cpp
+++ b/src/inputcomponents/kickdownswitch.cpp
@@ -1,5 +1,6 @@
 #include "kickdownswitch.hpp"
 #include "board_config.h"
+#include "kickdownswitch_logic.h"
 
 
 bool KickdownSwitch::last_state = false; // Initialize the last state to false
@@ -7,7 +8,7 @@ bool KickdownSwitch::last_state = false; // Initialize the last state to false
 bool KickdownSwitch::is_kickdown_newly_pressed(EgsBaseCan *egs_can_hal, uint32_t expire_time_ms)
 {
     bool current_state = pcb_gpio_matrix->is_kickdown_pressed() || egs_can_hal->get_kickdown(expire_time_ms);
-    bool result = current_state != KickdownSwitch::last_state;
+    bool result = kickdown_is_new_press(current_state, KickdownSwitch::last_state);
     KickdownSwitch::last_state = current_state;
     return result;
 }

--- a/src/inputcomponents/kickdownswitch_logic.cpp
+++ b/src/inputcomponents/kickdownswitch_logic.cpp
@@ -1,0 +1,5 @@
+#include "kickdownswitch_logic.h"
+
+bool kickdown_is_new_press(bool current_state, bool last_state) {
+    return current_state && !last_state;
+}

--- a/src/inputcomponents/kickdownswitch_logic.h
+++ b/src/inputcomponents/kickdownswitch_logic.h
@@ -1,0 +1,6 @@
+#ifndef KICKDOWNSWITCH_LOGIC_H
+#define KICKDOWNSWITCH_LOGIC_H
+
+bool kickdown_is_new_press(bool current_state, bool last_state);
+
+#endif

--- a/src/ioexpander.cpp
+++ b/src/ioexpander.cpp
@@ -2,6 +2,7 @@
 #include "esp_log.h"
 #include "clock.hpp"
 #include "board_config.h"
+#include "ioexpander_logic.h"
 
 IOExpander::IOExpander(gpio_num_t sda, gpio_num_t scl)
 {
@@ -123,15 +124,18 @@ bool IOExpander::is_data_valid(const uint32_t expire_time_ms) const
 
 inline bool IOExpander::get_bool_value(const pca_num_t bit, const uint8_t *i2c_rx_bytes)
 {
-	return (i2c_rx_bytes[0] >> bit) & 0b1;
+	if (i2c_rx_bytes == nullptr) {
+		return false;
+	}
+	return ioexpander_get_input_bit(i2c_rx_bytes[0], (int)bit);
 }
 
 inline void IOExpander::set_value(const bool value, const pca_num_t bit, uint8_t *i2c_tx_bytes)
 {
-	// reset bit and keep existing buffer
-	i2c_tx_bytes[1] &= ~(BIT(bit));
-	// set bit
-	i2c_tx_bytes[1] |= ((uint8_t)value) << bit;
+	if (i2c_tx_bytes == nullptr) {
+		return;
+	}
+	i2c_tx_bytes[1] = ioexpander_set_output_bit(i2c_tx_bytes[1], (int)bit, value);
 }
 
 uint8_t IOExpander::get_trrs(void)

--- a/src/ioexpander_logic.cpp
+++ b/src/ioexpander_logic.cpp
@@ -1,0 +1,24 @@
+#include "ioexpander_logic.h"
+
+bool ioexpander_is_valid_bit(int bit) {
+    return bit >= 0 && bit <= 7;
+}
+
+bool ioexpander_get_input_bit(uint8_t input_byte, int bit) {
+    if (!ioexpander_is_valid_bit(bit)) {
+        return false;
+    }
+    return ((input_byte >> bit) & 0x01u) != 0u;
+}
+
+uint8_t ioexpander_set_output_bit(uint8_t output_byte, int bit, bool value) {
+    if (!ioexpander_is_valid_bit(bit)) {
+        return output_byte;
+    }
+    uint8_t mask = (uint8_t)(1u << bit);
+    output_byte &= (uint8_t)(~mask);
+    if (value) {
+        output_byte |= mask;
+    }
+    return output_byte;
+}

--- a/src/ioexpander_logic.h
+++ b/src/ioexpander_logic.h
@@ -1,0 +1,10 @@
+#ifndef IOEXPANDER_LOGIC_H
+#define IOEXPANDER_LOGIC_H
+
+#include <stdint.h>
+
+bool ioexpander_is_valid_bit(int bit);
+bool ioexpander_get_input_bit(uint8_t input_byte, int bit);
+uint8_t ioexpander_set_output_bit(uint8_t output_byte, int bit, bool value);
+
+#endif

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -107,8 +107,8 @@ SPEAKER_POST_CODE setup_tcm()
                             if (nullptr != shifter)
                             {
                                 // init the CAN module
-                                egs_can_hal->~EgsBaseCan();
-                                free(egs_can_hal); // Delete fallback CAN
+                                delete egs_can_hal; // Delete fallback CAN
+                                egs_can_hal = nullptr;
                                 switch (VEHICLE_CONFIG.egs_can_type)
                                 {
                                 case 1:

--- a/src/nvs/eeprom_config.cpp
+++ b/src/nvs/eeprom_config.cpp
@@ -232,11 +232,11 @@ esp_err_t EEPROM::read_core_config(TCM_CORE_CONFIG* dest) {
                 ESP_LOG_LEVEL(ESP_LOG_ERROR, "EEPROM", "Error calling nvs_commit: %s", esp_err_to_name(result));
             } else {
                 ESP_LOG_LEVEL(ESP_LOG_INFO, "EEPROM", "New SCN  creation OK!");
-                memcpy(dest, &s, sizeof(s));
+                memcpy(dest, &c, sizeof(c));
                 result = ESP_OK;
             }
         }
-        return true;
+        return result;
     }
     return result;
 }

--- a/src/pressure_manager.cpp
+++ b/src/pressure_manager.cpp
@@ -72,7 +72,8 @@ PressureManager::PressureManager(SensorData* sensor_ptr, uint16_t max_torque) {
     default_data = TCC_PWM_MAP;
     tcc_pwm_map = new StoredMap(key_name, TCC_PWM_MAP_SIZE, pwm_tcc_x_headers, pwm_tcc_y_headers, 7, 5, default_data);
     if (this->tcc_pwm_map->init_status() != ESP_OK) {
-        delete[] this->tcc_pwm_map;
+        delete this->tcc_pwm_map;
+        this->tcc_pwm_map = nullptr;
     }
 
     /** Pressure fill time map **/
@@ -88,7 +89,8 @@ PressureManager::PressureManager(SensorData* sensor_ptr, uint16_t max_torque) {
     default_data = LARGE_NAG_FILL_TIME_MAP;
     fill_time_map = new StoredMap(key_name, FILL_TIME_MAP_SIZE, fill_t_x_headers, fill_t_y_headers, 4, 5, default_data);
     if (this->fill_time_map->init_status() != ESP_OK) {
-        delete[] this->fill_time_map;
+        delete this->fill_time_map;
+        this->fill_time_map = nullptr;
     }
 
     /** Pressure fill pressure map **/
@@ -105,7 +107,8 @@ PressureManager::PressureManager(SensorData* sensor_ptr, uint16_t max_torque) {
     default_data = NAG_FILL_PRESSURE_MAP;
     fill_pressure_map = new StoredMap(key_name, FILL_PRESSURE_MAP_SIZE, fill_p_x_headers, fill_p_y_headers, 1, 6, default_data);
     if (this->fill_pressure_map->init_status() != ESP_OK) {
-        delete[] this->fill_pressure_map;
+        delete this->fill_pressure_map;
+        this->fill_pressure_map = nullptr;
     }
 
     /** Pressure fill pressure map **/
@@ -121,7 +124,8 @@ PressureManager::PressureManager(SensorData* sensor_ptr, uint16_t max_torque) {
     default_data = NAG_FILL_LOW_PRESSURE_MAP;
     fill_low_pressure_map = new StoredMap(key_name, LOW_FILL_PRESSURE_MAP_SIZE, fill_lp_x_headers, fill_lp_y_headers, 1, 5, default_data);
     if (this->fill_low_pressure_map->init_status() != ESP_OK) {
-        delete[] this->fill_low_pressure_map;
+        delete this->fill_low_pressure_map;
+        this->fill_low_pressure_map = nullptr;
     }
 
     // Init MPC and SPC req pressures

--- a/src/pressure_manager.h
+++ b/src/pressure_manager.h
@@ -107,6 +107,8 @@ public:
     void set_spc_p_max(void);
 
     PressureManager(SensorData* sensor_ptr, uint16_t max_torque);
+    PressureManager(const PressureManager&) = delete;
+    PressureManager& operator=(const PressureManager&) = delete;
 
     /**
      * @brief Get the shift data object for the requested gear change

--- a/src/profiles.cpp
+++ b/src/profiles.cpp
@@ -38,7 +38,8 @@ AbstractProfile::AbstractProfile(bool is_diesel,
     }
     this->upshift_table = new StoredMap(key_name, SHIFT_MAP_SIZE, shift_table_x_header, upshift_y_headers, SHIFT_MAP_X_SIZE, SHIFT_MAP_Y_SIZE, default_map);
     if (this->upshift_table->init_status() != ESP_OK) {
-        delete[] this->upshift_table;
+        delete this->upshift_table;
+        this->upshift_table = nullptr;
     }
 
     /** Downshift map **/
@@ -51,7 +52,8 @@ AbstractProfile::AbstractProfile(bool is_diesel,
     }
     this->downshift_table = new StoredMap(key_name, SHIFT_MAP_SIZE, shift_table_x_header, downshift_y_headers, SHIFT_MAP_X_SIZE, SHIFT_MAP_Y_SIZE, default_map);
     if (this->downshift_table->init_status() != ESP_OK) {
-        delete[] this->downshift_table;
+        delete this->downshift_table;
+        this->downshift_table = nullptr;
     }
 
     // Up/downshift time tables
@@ -60,11 +62,13 @@ AbstractProfile::AbstractProfile(bool is_diesel,
     int16_t shift_rpm_points[5] = {(int16_t)1000,  (int16_t)(1000+(step_size)), (int16_t)(1000+(step_size*2)), (int16_t)(1000+(step_size*3)), redline};
     this->upshift_time_map = new StoredMap(upshift_time_map_name, SHIFT_TIME_MAP_SIZE, shift_time_table_x_header, const_cast<int16_t*>(shift_rpm_points), 6, 5, def_upshift_time_data);
     if (this->upshift_time_map->init_status() != ESP_OK) {
-        delete[] this->upshift_time_map;
+        delete this->upshift_time_map;
+        this->upshift_time_map = nullptr;
     }
     this->downshift_time_map = new StoredMap(downshift_time_map_name, SHIFT_TIME_MAP_SIZE, shift_time_table_x_header, const_cast<int16_t*>(shift_rpm_points), 6, 5, def_downshift_time_data);
     if (this->downshift_time_map->init_status() != ESP_OK) {
-        delete[] this->downshift_time_map;
+        delete this->downshift_time_map;
+        this->downshift_time_map = nullptr;
     }
 }
 

--- a/src/profiles.h
+++ b/src/profiles.h
@@ -65,6 +65,8 @@ public:
         const int16_t* def_upshift_time_data,
         const int16_t* def_downshift_time_data
     );
+    AbstractProfile(const AbstractProfile&) = delete;
+    AbstractProfile& operator=(const AbstractProfile&) = delete;
     // static AbstractProfile *profile_from_auto_ty(AutoProfile prof);
     virtual void update(SensorData* sensors) {};
     virtual GearboxProfile get_profile(void) const = 0;

--- a/src/sensors.cpp
+++ b/src/sensors.cpp
@@ -9,6 +9,7 @@
 #include "esp_timer.h"
 #include "esp_private/adc_private.h"
 #include "tcu_maths_impl.h"
+#include "sensors_logic.h"
 
 #define N_SENSOR_PULSES_PER_REV 60 // N2 and N3 are 60 pulses per revolution
 #define MAX_RPM_PCNT 10000
@@ -105,11 +106,13 @@ void Sensors::update(SensorDataRaw* dest) {
         else {
             dest->parking_lock = 0;
             adc_cali_raw_to_voltage(adc2_cal, adc_res, &adc_voltage);
-
-            int resistance = (adc_voltage * pcb_gpio_matrix->sensor_data.atf_r2_resistance) / (3300 - adc_voltage);
-
-            float out_x10 = interpolate_linear_array((int16_t)resistance, NUM_TEMP_POINTS, TFT_RESISTANCE_TAB[0], TFT_RESISTANCE_TAB[1]);
-            dest->atf_temp_c = (int16_t)(out_x10 / 10.0);
+            int resistance = 0;
+            if (sensors_try_calc_atf_resistance(adc_voltage, pcb_gpio_matrix->sensor_data.atf_r2_resistance, &resistance)) {
+                float out_x10 = interpolate_linear_array((int16_t)resistance, NUM_TEMP_POINTS, TFT_RESISTANCE_TAB[0], TFT_RESISTANCE_TAB[1]);
+                dest->atf_temp_c = (int16_t)(out_x10 / 10.0);
+            } else {
+                dest->atf_temp_c = INT_MAX;
+            }
         }
     }
 }

--- a/src/sensors_logic.cpp
+++ b/src/sensors_logic.cpp
@@ -1,0 +1,13 @@
+#include "sensors_logic.h"
+
+bool sensors_try_calc_atf_resistance(int adc_voltage_mv, uint16_t r2_resistance_ohm, int* out_resistance_ohm) {
+    if (out_resistance_ohm == nullptr) {
+        return false;
+    }
+    int denom = 3300 - adc_voltage_mv;
+    if (adc_voltage_mv < 0 || denom <= 0) {
+        return false;
+    }
+    *out_resistance_ohm = (adc_voltage_mv * r2_resistance_ohm) / denom;
+    return true;
+}

--- a/src/sensors_logic.h
+++ b/src/sensors_logic.h
@@ -1,0 +1,8 @@
+#ifndef SENSORS_LOGIC_H
+#define SENSORS_LOGIC_H
+
+#include <stdint.h>
+
+bool sensors_try_calc_atf_resistance(int adc_voltage_mv, uint16_t r2_resistance_ohm, int* out_resistance_ohm);
+
+#endif

--- a/src/shifter/shifter_ewm.h
+++ b/src/shifter/shifter_ewm.h
@@ -11,6 +11,8 @@ class ShifterEwm : public Shifter
 {
 public:
 	ShifterEwm(TCM_CORE_CONFIG* vehicle_config, ETS_MODULE_SETTINGS* shifter_settings);
+	ShifterEwm(const ShifterEwm&) = delete;
+	ShifterEwm& operator=(const ShifterEwm&) = delete;
 	ShifterPosition get_shifter_position(const uint32_t expire_time_ms) override;
 	AbstractProfile* get_profile(const uint32_t expire_time_ms) override;
 	void set_program_button_pressed(const bool is_pressed, const ProfileSwitchPos pos);

--- a/src/shifter/shifter_trrs.h
+++ b/src/shifter/shifter_trrs.h
@@ -10,6 +10,8 @@ class ShifterTrrs : public Shifter
 {
 public:
     ShifterTrrs(TCM_CORE_CONFIG* vehicle_config, BoardGpioMatrix *board);
+    ShifterTrrs(const ShifterTrrs&) = delete;
+    ShifterTrrs& operator=(const ShifterTrrs&) = delete;
     ShifterPosition get_shifter_position(const uint32_t expire_time_ms) override;    
     AbstractProfile* get_profile(const uint32_t expire_time_ms) override;
     DiagProfileInputState diag_get_profile_input() override;

--- a/src/solenoids/pwm_solenoid.cpp
+++ b/src/solenoids/pwm_solenoid.cpp
@@ -51,11 +51,14 @@ set_err:
 
 uint16_t PwmSolenoid::get_current() const {
     uint32_t raw = this->current_adc_reading;
-    uint16_t ret = 0;
+    int mv = 0;
     if (0 != raw) {
-        adc_cali_raw_to_voltage(adc1_cal, raw, reinterpret_cast<int*>(&ret));
+        adc_cali_raw_to_voltage(adc1_cal, raw, &mv);
     }
-    return ret * pcb_gpio_matrix->sensor_data.current_sense_multi;
+    if (mv < 0) {
+        mv = 0;
+    }
+    return (uint16_t)mv * pcb_gpio_matrix->sensor_data.current_sense_multi;
 }
 
 uint16_t PwmSolenoid::get_pwm_raw() const

--- a/src/stored_data.h
+++ b/src/stored_data.h
@@ -5,6 +5,7 @@
 
 class StoredData {
 	public:
+        virtual ~StoredData() = default;
     	esp_err_t init_status(void);
 
         virtual esp_err_t read_from_eeprom(const char *key_name, uint16_t expected_size) = 0;

--- a/src/tcu_io/tcu_io.cpp
+++ b/src/tcu_io/tcu_io.cpp
@@ -144,13 +144,15 @@ void update_tft_sensor() {
     add_to_onepoll_sensor(&onepoll_parking_lock, raw_sensors.parking_lock);
 
     bool reset_average = was_reading_from_engine != atf_from_engine_temp; // State change
-    int temperature = 25;
+    int16_t temperature = INT16_MAX;
     if (atf_from_engine_temp) {
         // Request value from CAN
-        temperature = onepoll_motor_temperature.current_value;
+        temperature = TCUIO::motor_temperature();
     } else {
         // Use TFT value
-        temperature = raw_sensors.atf_temp_c;
+        if (raw_sensors.atf_temp_c != INT_MAX) {
+            temperature = raw_sensors.atf_temp_c;
+        }
     }
     // Temperature might be INT16_MAX (Something wrong with the signal)
     add_to_smoothed_sensor(&smoothed_sensor_atf_temp, temperature, reset_average);
@@ -277,8 +279,8 @@ uint16_t TCUIO::calc_turbine_rpm(const uint16_t n2, const uint16_t n3) {
 }
 
 uint8_t TCUIO::parking_lock() { return get_onepoll_sensor_val(&onepoll_parking_lock, 0); }
-int16_t TCUIO::atf_temperature() { return smoothed_sensor_atf_temp.last_value/100;}
-uint16_t TCUIO::battery_mv() { return smoothed_sensor_vbatt.last_value/100;}
+int16_t TCUIO::atf_temperature() { return get_smoothed_sensor_val_signed(&smoothed_sensor_atf_temp, 2); }
+uint16_t TCUIO::battery_mv() { return get_smoothed_sensor_val_unsigned(&smoothed_sensor_vbatt, 2); }
 uint16_t TCUIO::n2_rpm() { 
     return get_smoothed_sensor_val_unsigned(&smoothed_sensor_n2_rpm, 0); 
 }

--- a/src/torque_converter.cpp
+++ b/src/torque_converter.cpp
@@ -30,17 +30,20 @@ TorqueConverter::TorqueConverter(uint16_t max_gb_rating)  {
     const int16_t adapt_map_y_headers[5] = {1,2,3,4,5}; // Gear
     this->tcc_slip_map = new StoredMap(NVS_KEY_TCC_ADAPT_SLIP_MAP, TCC_SLIP_ADAPT_MAP_SIZE, adapt_map_x_headers, adapt_map_y_headers, LOAD_SIZE, 5, TCC_SLIP_ADAPT_MAP);
     if (this->tcc_slip_map->init_status() != ESP_OK) {
-        delete[] this->tcc_slip_map;
+        delete this->tcc_slip_map;
+        this->tcc_slip_map = nullptr;
     }
 
     this->tcc_lock_map = new StoredMap(NVS_KEY_TCC_ADAPT_LOCK_MAP, TCC_SLIP_ADAPT_MAP_SIZE, adapt_map_x_headers, adapt_map_y_headers, LOAD_SIZE, 5, TCC_LOCK_ADAPT_MAP);
     if (this->tcc_lock_map->init_status() != ESP_OK) {
-        delete[] this->tcc_lock_map;
+        delete this->tcc_lock_map;
+        this->tcc_lock_map = nullptr;
     }
 
     this->slip_rpm_target_map = new StoredMap(NVS_KEY_TCC_SLIP_TARGET_MAP, TCC_RPM_TARGET_MAP_SIZE, rpm_map_x_headers, rpm_map_y_headers, 11, 8, TCC_RPM_TARGET_MAP);
     if (this->slip_rpm_target_map->init_status() != ESP_OK) {
-        delete[] this->slip_rpm_target_map;
+        delete this->slip_rpm_target_map;
+        this->slip_rpm_target_map = nullptr;
     }
 
     this->init_tables_ok = (this->tcc_slip_map != nullptr) && (this->tcc_lock_map != nullptr) && (this->slip_rpm_target_map != nullptr);
@@ -159,7 +162,6 @@ void TorqueConverter::update(GearboxGear curr_gear, GearboxGear targ_gear, Press
                 slipping_rpm_targ = MAX(SLIP_V_WHEN_LOCKED, slipping_rpm_targ);
             }
         }
-        slipping_rpm_targ = slipping_rpm_targ;
         if (is_shifting) {
             // Check previous target
             bool open_tcc = false;

--- a/src/torque_converter.h
+++ b/src/torque_converter.h
@@ -21,6 +21,8 @@ enum class InternalTccState {
 class TorqueConverter {
     public:
         TorqueConverter(uint16_t max_gb_rating);
+        TorqueConverter(const TorqueConverter&) = delete;
+        TorqueConverter& operator=(const TorqueConverter&) = delete;
 
         /**
          * @brief Lets the torque converter code poll and see what is next to do with the converters

--- a/test/main.cpp
+++ b/test/main.cpp
@@ -1,40 +1,59 @@
-#include "moving_average.h"
 #include <unity.h>
+#include <type_traits>
 #include "freertos/FreeRTOS.h"
 #include "freertos/task.h"
+#include "tcu_maths.h"
+#include "stored_data.h"
+#include "torque_converter.h"
+#include "pressure_manager.h"
+#include "profiles.h"
+#include "adaptation/shift_adaptation.h"
+#include "diag/kwp2000.h"
+#include "gearbox.h"
+#include "shifter/shifter_ewm.h"
+#include "shifter/shifter_trrs.h"
 
-void test_ma_back() {
-    MovingUnsignedAverage* ma = new MovingUnsignedAverage(3, true); // 3 elements (Allocate to IRAM as we don't have PSRAM in test ENV)
-    TEST_ASSERT_EQUAL_INT(ma->back(), 0);
-    ma->add_sample(1);
-    ma->add_sample(2);
-    TEST_ASSERT_EQUAL_INT(ma->back(), 1);
-    ma->add_sample(3);
-    TEST_ASSERT_EQUAL_INT(ma->back(), 1);
-    ma->add_sample(4);
-    TEST_ASSERT_EQUAL_INT(ma->back(), 2);
+// Compile-time regression guards for ownership semantics.
+static_assert(std::has_virtual_destructor<StoredData>::value, "StoredData must have a virtual destructor");
+static_assert(!std::is_copy_constructible<TorqueConverter>::value, "TorqueConverter must remain non-copyable");
+static_assert(!std::is_copy_constructible<PressureManager>::value, "PressureManager must remain non-copyable");
+static_assert(!std::is_copy_constructible<AbstractProfile>::value, "AbstractProfile must remain non-copyable");
+static_assert(!std::is_copy_constructible<ShiftAdaptationSystem>::value, "ShiftAdaptationSystem must remain non-copyable");
+static_assert(!std::is_copy_constructible<Kwp2000_server>::value, "Kwp2000_server must remain non-copyable");
+static_assert(!std::is_copy_constructible<Gearbox>::value, "Gearbox must remain non-copyable");
+static_assert(!std::is_copy_constructible<ShifterEwm>::value, "ShifterEwm must remain non-copyable");
+static_assert(!std::is_copy_constructible<ShifterTrrs>::value, "ShifterTrrs must remain non-copyable");
+
+void test_first_order_filter_int() {
+    // Weighted average: (new + n*last)/(n+1)
+    TEST_ASSERT_EQUAL_INT32(25, first_order_filter(3, 100, 0));
+    TEST_ASSERT_EQUAL_INT32(75, first_order_filter(3, 0, 100));
+    // Guard branch for 0xFF sample_count should behave like 0xFE.
+    TEST_ASSERT_EQUAL_INT32(0, first_order_filter(0xFF, 255, 0));
 }
 
-void test_ma_front() {
-    MovingUnsignedAverage* ma = new MovingUnsignedAverage(3, true); // 3 elements (Allocate to IRAM as we don't have PSRAM in test ENV)
-    TEST_ASSERT_EQUAL_INT(ma->front(), 0);
-    // Push a value
-    ma->add_sample(1);
-    TEST_ASSERT_EQUAL_INT(ma->front(), 1);
-    // Push another value
-    ma->add_sample(2);
-    TEST_ASSERT_EQUAL_INT(ma->front(), 2);
-    // Push another value
-    ma->add_sample(3);
-    TEST_ASSERT_EQUAL_INT(ma->front(), 3);
-    // Push another value (Overwrite idx 0)
-    ma->add_sample(4);
-    TEST_ASSERT_EQUAL_INT(ma->front(), 4);
+void test_first_order_filter_float() {
+    TEST_ASSERT_FLOAT_WITHIN(0.001f, 25.0f, first_order_filter_f(3, 100, 0.0f));
+    TEST_ASSERT_FLOAT_WITHIN(0.001f, 75.0f, first_order_filter_f(3, 0, 100.0f));
+    TEST_ASSERT_FLOAT_WITHIN(0.001f, 1.0f, first_order_filter_f(0xFF, 255, 0.0f));
+}
+
+void test_ownership_contracts() {
+    TEST_ASSERT_TRUE(std::has_virtual_destructor<StoredData>::value);
+    TEST_ASSERT_FALSE(std::is_copy_constructible<TorqueConverter>::value);
+    TEST_ASSERT_FALSE(std::is_copy_constructible<PressureManager>::value);
+    TEST_ASSERT_FALSE(std::is_copy_constructible<AbstractProfile>::value);
+    TEST_ASSERT_FALSE(std::is_copy_constructible<ShiftAdaptationSystem>::value);
+    TEST_ASSERT_FALSE(std::is_copy_constructible<Kwp2000_server>::value);
+    TEST_ASSERT_FALSE(std::is_copy_constructible<Gearbox>::value);
+    TEST_ASSERT_FALSE(std::is_copy_constructible<ShifterEwm>::value);
+    TEST_ASSERT_FALSE(std::is_copy_constructible<ShifterTrrs>::value);
 }
 
 extern "C" void app_main(void) {
     UNITY_BEGIN();
-    RUN_TEST(test_ma_back);
-    RUN_TEST(test_ma_front);
+    RUN_TEST(test_first_order_filter_int);
+    RUN_TEST(test_first_order_filter_float);
+    RUN_TEST(test_ownership_contracts);
     UNITY_END();
 }


### PR DESCRIPTION
Stacked PR Notice:
- This branch is stacked after PR1 due base-repo branch permission limits.
- Please review commit ab9fa1f for this PR's logical delta.

Summary:
- Hardens low-level IO paths (bit guards, sensor math safety, lifecycle safety).
- Fixes kickdown rising-edge semantics.
- Adds testable helper modules and host low-level logic regression tests.
- Improves Custom CAN signal decoding and torque-request mapping path.

Validation:
- host tests built and executed with CMake and CTest.
- tests passing.

## PR Dependencies
- Depends on #106: https://github.com/rnd-ash/ultimate-nag52-fw/pull/106
