### PR TITLE
Record shifts on the TCU at 50 Hz, and score their quality

### DIFF
--- a/src/diag/diag_data.h
+++ b/src/diag/diag_data.h
@@ -38,6 +38,9 @@
 
 #define RLI_CLUTCH_SPEEDS   0x30
 #define RLI_SHIFTING_ALGO   0x31
+// Header of the high rate shift recorder. The samples themselves are pulled with
+// ReadMemoryByAddress from the `buffer_addr` it publishes - see src/shift_trace.h.
+#define RLI_SHIFT_TRACE     0x33
 #define RLI_DRIVING_DYNAMIC 0x32
 
 #define RLI_EGS_CAL_LEN     0xFB // EGS Calibration structure length

--- a/src/diag/kwp2000.cpp
+++ b/src/diag/kwp2000.cpp
@@ -1,4 +1,5 @@
 #include "kwp2000.h"
+#include "shift_trace.h"
 #include <esp_ota_ops.h>
 #include <string>
 #include <time.h>
@@ -599,6 +600,16 @@ void Kwp2000_server::process_read_data_local_ident(uint8_t* args, uint16_t arg_l
     } else if (args[0] == RLI_CLUTCH_SPEEDS) {
         ClutchSpeeds r = gearbox->diag_get_clutch_speeds();
         make_diag_pos_msg(SID_READ_DATA_LOCAL_IDENT, RLI_CLUTCH_SPEEDS, (uint8_t*)&r, sizeof(ClutchSpeeds));
+    } else if (args[0] == RLI_SHIFT_TRACE) {
+        // Header only. The samples are pulled with ReadMemoryByAddress from
+        // `buffer_addr`, at most 255 bytes per response and paced by the host, so
+        // the USB serial bridge's FIFO is never burst through.
+        const ShiftTraceHeader* h = ShiftTrace::get_header();
+        if (nullptr == h) {
+            make_diag_neg_msg(SID_READ_DATA_LOCAL_IDENT, NRC_CONDITIONS_NOT_CORRECT_REQ_SEQ_ERROR);
+        } else {
+            make_diag_pos_msg(SID_READ_DATA_LOCAL_IDENT, RLI_SHIFT_TRACE, (uint8_t*)h, sizeof(ShiftTraceHeader));
+        }
     } else if (args[0] == RLI_SHIFTING_ALGO) {
         ShiftAlgoFeedback r = gearbox->algo_feedback;
         make_diag_pos_msg(SID_READ_DATA_LOCAL_IDENT, RLI_SHIFTING_ALGO, (uint8_t*)&r, sizeof(ShiftAlgoFeedback));

--- a/src/gearbox.cpp
+++ b/src/gearbox.cpp
@@ -1,4 +1,5 @@
 #include "gearbox.h"
+#include "shift_trace.h"
 #include "common_structs_ops.h"
 #include "nvs/eeprom_config.h"
 #include "adv_opts.h"
@@ -1024,6 +1025,7 @@ void Gearbox::controller_loop()
 {
     ShifterPosition last_position = ShifterPosition::SignalNotAvailable;
     ESP_LOG_LEVEL(ESP_LOG_INFO, "GEARBOX", "GEARBOX START!");
+    ShiftTrace::init();
     uint32_t expire_check = GET_CLOCK_TIME() + 100; // 100ms
     egs_can_hal->set_safe_start(true);
     sol_tcc->isr_enable(); // Safe to enable ISR now that all init is done
@@ -1651,6 +1653,16 @@ void Gearbox::controller_loop()
             }
         }
         portEXIT_CRITICAL(&this->profile_mutex);
+        // High rate shift recorder. This loop is the algorithm's own 20 ms period,
+        // so the capture is lossless; the sampler is O(1) and allocation free.
+        ShiftTrace::sample(&this->sensor_data, &this->algo_feedback, this->shifting,
+            (uint8_t)gear_to_idx_lookup(this->actual_gear), (uint8_t)gear_to_idx_lookup(this->target_gear),
+            this->pressure_mgr->get_corrected_spc_pressure(),
+            this->pressure_mgr->get_corrected_modulating_pressure(),
+            this->pressure_mgr->get_active_shift_circuits(),
+            (this->output_data.ctrl_type == TorqueRequestControlType::None)
+                ? INT16_MAX : (int16_t)this->output_data.torque_req_amount,
+            (int16_t)this->sensor_data.converted_torque);
         uint32_t time = GET_CLOCK_TIME() - start;
         if (time < 20) {
             vTaskDelay((20 - time) / portTICK_PERIOD_MS); // 50 updates/sec!

--- a/src/models/vehicle_geometry.h
+++ b/src/models/vehicle_geometry.h
@@ -1,0 +1,35 @@
+#ifndef __VEHICLE_GEOMETRY_H
+#define __VEHICLE_GEOMETRY_H
+
+#include "nvs/eeprom_config.h"
+
+/**
+ * @brief Metres per second of road speed per RPM of the output shaft.
+ *
+ * The one place the wheel circumference and final drive are turned into a road
+ * speed, so that everything reporting in SI agrees and there is a single place
+ * to be wrong. Parameters and reported metrics are stated in SI wherever it is
+ * reasonable, and this is what makes that possible.
+ *
+ * Accuracy barely matters for what uses it. A properly plus-sized wheel changes
+ * the circumference by about 1 % (195/65R15 and 225/45R17 are within 0.1 % of
+ * each other) and a 20 inch wheel nobody would fit to a W210 by 8 %. What DOES
+ * matter is not silently returning zero, which is what the guards below are for:
+ * the factory default config is 2850 mm on a 1.000 final drive, i.e. a
+ * placeholder, and an unconfigured TCU reporting a jerk of 0 would look like a
+ * perfect shift rather than an unconfigured TCU.
+ */
+static inline float mps_per_output_rpm(void) {
+    // Placeholder-config fallback: a 1.975 m circumference on a 3.07 final drive,
+    // which is an ordinary saloon. Wrong for any given car, but the right order
+    // of magnitude, where 0 is not.
+    const float FALLBACK = 1.975f / 60.0f / 3.070f;
+    if (0u == VEHICLE_CONFIG.diff_ratio || 0u == VEHICLE_CONFIG.wheel_circumference) {
+        return FALLBACK;
+    }
+    // circumference is mm, diff_ratio is x1000
+    return ((float)VEHICLE_CONFIG.wheel_circumference / 1000.0f) / 60.0f /
+           ((float)VEHICLE_CONFIG.diff_ratio / 1000.0f);
+}
+
+#endif

--- a/src/shift_trace.cpp
+++ b/src/shift_trace.cpp
@@ -1,0 +1,276 @@
+#include "shift_trace.h"
+#include "models/vehicle_geometry.h"
+#include "tcu_alloc.h"
+#include "clock.hpp"
+#include "esp_log.h"
+#include "nvs/eeprom_config.h"
+#include "egs_calibration/calibration_structs.h"
+#include <math.h>
+#include <string.h>
+
+static ShiftTraceHeader trace_header = {};
+static ShiftTraceSample* trace_ring = nullptr;
+static bool was_shifting = false;
+
+
+/**
+ * @brief Running state for the shift quality metrics.
+ *
+ * Accumulated one sample at a time so it costs O(1) per control loop iteration
+ * and needs no allocation. See ShiftQuality in the header for what each number
+ * means and why they are a vector rather than a score.
+ */
+/**
+ * @brief Samples of output speed kept for the derivative baseline.
+ *
+ * Output speed is an integer rpm, so differentiating it twice over one 20 ms
+ * step has a floor: one rpm of wobble is 1/dt^2 * mps_per_output_rpm, which on
+ * this car is 29.7 m/s^3 - above the whole comfort range. The 2026-09-08 drive
+ * measured a median peak_jerk of 30.5 against that floor of 29.7, i.e. the
+ * metric was reporting its own quantisation and not the shift. Acceleration had
+ * the same problem: its floor is 53 rpm/s and torque_hole was reading 52.
+ *
+ * Widening the baseline to three samples divides the floor by nine (3.3 m/s^3)
+ * and still resolves an inertia phase, which lasts 100-200 ms against this
+ * 57 ms window. Measured over the same 39 shifts the median becomes 6.6 m/s^3,
+ * which is inside the published comfort range and therefore actually
+ * discriminates between a smooth shift and a harsh one.
+ */
+#define QUALITY_DERIV_SPAN 3
+#define QUALITY_HIST (2 * QUALITY_DERIV_SPAN + 1)
+
+static struct {
+    uint32_t t_start;
+    float ratio_start;
+    float ratio_target;
+    float accel_base;       // output shaft accel before the shift, rpm/s
+    float accel_prev;
+    uint16_t out_hist[QUALITY_HIST];
+    uint32_t t_hist[QUALITY_HIST];
+    uint8_t hist_n;
+    uint16_t out_prev;
+    uint16_t in_prev;
+    uint32_t t_prev;
+    int32_t slip_prev;
+    float energy;
+    float peak_jerk;
+    float min_accel;
+    uint16_t response_ms;
+    uint16_t lockup_rate;
+    uint8_t osc;
+    bool settling;
+} q = {};
+
+// Vehicle longitudinal speed per rpm of output shaft, m/s. Set once at init.
+// The applying clutch only starts to transmit once its pressure beats the return
+// spring, so slip before that dissipates nothing. The calibration puts the
+// springs at 1139-1289 mBar on this box.
+#define QUALITY_SPRING_MBAR 1300
+// Input shaft inertia, kg m^2, for the clutch torque estimate. Fitted from 302
+// logged inertia phase samples across four drives.
+#define QUALITY_INPUT_INERTIA 0.16f
+
+void ShiftTrace::init(void) {
+    // PSRAM: 13 KB is nothing there, and keeping it out of internal RAM leaves
+    // the shift task's headroom alone.
+    // TCU_HEAP_ALLOC is already the PSRAM heap on ESP32.
+    trace_ring = static_cast<ShiftTraceSample*>(
+        TCU_HEAP_ALLOC(SHIFT_TRACE_CAPACITY * sizeof(ShiftTraceSample)));
+    if (nullptr == trace_ring) {
+        // Not fatal - the TCU drives fine without a trace, so say so and move on.
+        ESP_LOG_LEVEL(ESP_LOG_WARN, "TRACE", "Shift trace buffer allocation failed, tracing disabled");
+        return;
+    }
+    memset(trace_ring, 0x00, SHIFT_TRACE_CAPACITY * sizeof(ShiftTraceSample));
+    trace_header.magic = SHIFT_TRACE_MAGIC;
+    trace_header.version = SHIFT_TRACE_VERSION;
+    trace_header.sample_size = (uint8_t)sizeof(ShiftTraceSample);
+    trace_header.capacity = (uint16_t)SHIFT_TRACE_CAPACITY;
+    trace_header.buffer_addr = (uint32_t)trace_ring;
+    trace_header.seq = 0;
+    trace_header.dropped = 0;
+    trace_header.n_events = 0;
+    ESP_LOG_LEVEL(ESP_LOG_INFO, "TRACE", "Shift trace ready: %u samples x %u bytes at 0x%08X (%u ms of history)",
+        (unsigned)SHIFT_TRACE_CAPACITY, (unsigned)sizeof(ShiftTraceSample),
+        (unsigned)trace_header.buffer_addr, (unsigned)(SHIFT_TRACE_CAPACITY * 20u));
+}
+
+const ShiftTraceHeader* ShiftTrace::get_header(void) {
+    return (nullptr == trace_ring) ? nullptr : &trace_header;
+}
+
+/**
+ * @brief Start a new event, retiring the oldest if the list is full.
+ *
+ * Events are kept newest-last so the host can walk them in order. Four is
+ * enough: a shift's window is ~2.3 s and draining it costs ~72 ms, while the
+ * shortest gap between shifts seen on the road is ~1.9 s.
+ */
+static void push_event(uint32_t seq, uint8_t from, uint8_t to, uint8_t pedal) {
+    if (trace_header.n_events == SHIFT_TRACE_EVENTS) {
+        // Oldest event is about to be lost. If the host never read it, its
+        // samples are long gone from the ring too - count it so a gap in the
+        // recorded shifts is visible rather than silent.
+        if (0 == trace_header.events[0].done ||
+            (trace_header.seq - trace_header.events[0].seq_start) >= SHIFT_TRACE_CAPACITY) {
+            trace_header.dropped += 1;
+        }
+        memmove(&trace_header.events[0], &trace_header.events[1],
+                sizeof(ShiftTraceEvent) * (SHIFT_TRACE_EVENTS - 1));
+        trace_header.n_events -= 1;
+    }
+    ShiftTraceEvent* e = &trace_header.events[trace_header.n_events];
+    e->seq_start = seq;
+    e->seq_end = seq;
+    e->gear_from = from;
+    e->gear_to = to;
+    e->done = 0;
+    e->pedal_start = pedal;
+    memset(&e->quality, 0, sizeof(ShiftQuality));
+    trace_header.n_events += 1;
+}
+
+void ShiftTrace::sample(const SensorData* sd, const ShiftAlgoFeedback* algo, bool shifting,
+                        uint8_t gear_actual, uint8_t gear_target, uint16_t spc, uint16_t mpc,
+                        uint8_t circuit_flags, int16_t trq_req_amount, int16_t engine_torque) {
+    if (nullptr == trace_ring || nullptr == sd || nullptr == algo) {
+        return;
+    }
+    ShiftTraceSample* s = &trace_ring[trace_header.seq % SHIFT_TRACE_CAPACITY];
+    s->t_ms = GET_CLOCK_TIME();
+    s->input_rpm = sd->input_rpm;
+    s->output_rpm = sd->output_rpm;
+    s->engine_rpm = sd->engine_rpm;
+    s->input_torque = sd->input_torque;
+    s->p_on = algo->p_on;
+    s->p_off = algo->p_off;
+    s->spc = spc;
+    s->mpc = mpc;
+    s->phase = algo->shift_phase;
+    s->subphase_shift = algo->subphase_shift;
+    s->subphase_mod = algo->subphase_mod;
+    s->flags = (shifting ? 0x01u : 0x00u) | (uint8_t)((circuit_flags & 0x0Fu) << 1);
+    s->pedal = (sd->pedal_pos > 250) ? 250u : (uint8_t)sd->pedal_pos;
+    s->gear = (uint8_t)((gear_actual & 0x0Fu) << 4 | (gear_target & 0x0Fu));
+    s->trq_req_amount = trq_req_amount;
+    s->engine_torque = engine_torque;
+
+    // Objective shift quality, accumulated as the shift runs.
+    //
+    // Both derivatives are taken over QUALITY_DERIV_SPAN samples rather than one,
+    // because output speed is quantised to 1 rpm and a single-step second
+    // difference measures that quantum and nothing else. See the note above.
+    for (uint8_t i = 0; i < QUALITY_HIST - 1; i++) {
+        q.out_hist[i] = q.out_hist[i + 1];
+        q.t_hist[i] = q.t_hist[i + 1];
+    }
+    q.out_hist[QUALITY_HIST - 1] = s->output_rpm;
+    q.t_hist[QUALITY_HIST - 1] = s->t_ms;
+    if (q.hist_n < QUALITY_HIST) { q.hist_n += 1; }
+
+    float accel = q.accel_prev;
+    bool accel_ok = false;
+    if (QUALITY_HIST == q.hist_n) {
+        const uint8_t MID = QUALITY_DERIV_SPAN;
+        const uint8_t END = QUALITY_HIST - 1;
+        float dt_new = (float)(q.t_hist[END] - q.t_hist[MID]) / 1000.0f;
+        float dt_old = (float)(q.t_hist[MID] - q.t_hist[0]) / 1000.0f;
+        // A gap means the ring straddles a stall or a dropped cycle; skip it
+        // rather than report the gap as a huge acceleration.
+        if (dt_new > 0.0f && dt_old > 0.0f && dt_new < 0.25f && dt_old < 0.25f) {
+            accel = ((float)q.out_hist[END] - (float)q.out_hist[MID]) / dt_new;
+            float accel_older = ((float)q.out_hist[MID] - (float)q.out_hist[0]) / dt_old;
+            // The two accelerations are centred half a window apart.
+            float dt_jerk = (dt_new + dt_old) / 2.0f;
+            accel_ok = true;
+            if (shifting || q.settling) {
+                float jerk = fabsf(accel - accel_older) / dt_jerk * mps_per_output_rpm();
+                if (jerk > q.peak_jerk) { q.peak_jerk = jerk; }
+            }
+        }
+    }
+    uint32_t dt_ms = (q.t_prev == 0) ? 0 : (s->t_ms - q.t_prev);
+    if (dt_ms > 0 && dt_ms < 200) {
+        float dt = dt_ms / 1000.0f;
+        if (shifting) {
+            if (accel_ok && accel < q.min_accel) { q.min_accel = accel; }
+            int32_t slip = (s->p_on > QUALITY_SPRING_MBAR) ? abs(algo->s_on) : -1;
+            if (slip >= 0 && q.slip_prev >= 0) {
+                float dw = ((float)s->input_rpm - (float)q.in_prev) / dt;
+                float t_clutch = fabsf(QUALITY_INPUT_INERTIA * dw * 0.10472f) +
+                                 fabsf((float)sd->input_torque);
+                q.energy += t_clutch * ((float)slip * 0.10472f) * dt;
+                if (q.slip_prev > slip) {
+                    uint16_t rate = (uint16_t)((q.slip_prev - slip) / dt);
+                    if (rate > q.lockup_rate) { q.lockup_rate = rate; }
+                }
+            }
+            q.slip_prev = slip;
+            // Response: how long before the ratio actually starts to move.
+            if (0 == q.response_ms && s->output_rpm > 150 && q.ratio_target > 0.0f) {
+                float r = (float)s->input_rpm / (float)s->output_rpm;
+                float span = q.ratio_target - q.ratio_start;
+                if (span != 0.0f && fabsf((r - q.ratio_start) / span) > 0.10f) {
+                    q.response_ms = (uint16_t)(s->t_ms - q.t_start);
+                }
+            }
+        } else if (q.settling) {
+            // Driveline ringing after engagement: reversals about the pre-shift level
+            if (accel_ok && ((q.accel_prev - q.accel_base) * (accel - q.accel_base)) < 0.0f && q.osc < 255) {
+                q.osc += 1;
+            }
+            if (s->t_ms - q.t_start > 600u + (uint32_t)trace_header.events[trace_header.n_events - 1].quality.duration_ms) {
+                q.settling = false;
+            }
+        }
+        if (accel_ok) { q.accel_prev = accel; }
+    }
+
+    // Shift boundaries are detected here rather than hooked into elapse_shift,
+    // so the shift control path is untouched.
+    if (shifting && !was_shifting) {
+        push_event(trace_header.seq, gear_actual, gear_target, s->pedal);
+        // Reset the accumulators and latch the starting conditions.
+        q.t_start = s->t_ms;
+        q.ratio_start = (s->output_rpm > 150) ? ((float)s->input_rpm / (float)s->output_rpm) : 0.0f;
+        q.ratio_target = 0.0f;
+        if (gear_target >= 1 && gear_target <= 7 && MECH_PTR != nullptr) {
+            q.ratio_target = (float)MECH_PTR->ratio_table[gear_target] / 1000.0f;
+        }
+        q.accel_base = q.accel_prev;
+        q.energy = 0.0f;
+        q.peak_jerk = 0.0f;
+        q.min_accel = q.accel_prev;
+        q.response_ms = 0;
+        q.lockup_rate = 0;
+        q.osc = 0;
+        q.slip_prev = -1;
+        q.settling = false;
+    } else if (!shifting && was_shifting && trace_header.n_events > 0) {
+        ShiftTraceEvent* e = &trace_header.events[trace_header.n_events - 1];
+        if (0 == e->done) {
+            e->seq_end = trace_header.seq;
+            e->done = 1;
+            e->quality.duration_ms = (uint16_t)MIN(65535u, s->t_ms - q.t_start);
+            e->quality.response_ms = q.response_ms;
+            e->quality.peak_jerk = (uint16_t)MIN(65535.0f, q.peak_jerk * 1000.0f);
+            e->quality.torque_hole = (uint16_t)MIN(65535.0f, MAX(0.0f, q.accel_base - q.min_accel));
+            e->quality.slip_energy_j = (uint32_t)MAX(0.0f, q.energy);
+            e->quality.lockup_rate = q.lockup_rate;
+            e->quality.settle_osc = 0;
+            e->quality.valid = 1;
+            q.settling = true;      // keep watching for driveline ringing
+        }
+    }
+    if (!shifting && !q.settling && trace_header.n_events > 0) {
+        ShiftTraceEvent* e = &trace_header.events[trace_header.n_events - 1];
+        if (e->quality.valid && e->quality.settle_osc == 0 && q.osc > 0) {
+            e->quality.settle_osc = q.osc;
+        }
+    }
+    q.out_prev = s->output_rpm;
+    q.in_prev = s->input_rpm;
+    q.t_prev = s->t_ms;
+    was_shifting = shifting;
+    trace_header.seq += 1;
+}

--- a/src/shift_trace.h
+++ b/src/shift_trace.h
@@ -1,0 +1,144 @@
+#ifndef SHIFT_TRACE_H
+#define SHIFT_TRACE_H
+
+#include <stdint.h>
+#include "common_structs.h"
+
+/**
+ * @brief High rate shift recorder.
+ *
+ * The diagnostic link is request/response, so a host poll of the default nine
+ * records takes 52.5 ms (measured median over 29944 cycles across four drives),
+ * i.e. 19 Hz. The sensors and the shift algorithm both update every 20 ms, so
+ * polling captured only one update in 2.6 - 62 % of them never left the TCU,
+ * and which ones survived drifted arbitrarily against the shift. A shift's
+ * inertia phase lasts 100-200 ms, leaving about three aliased samples: too few
+ * to see how a shift went, let alone to fit a model to it.
+ *
+ * So the TCU records it itself. A ring in PSRAM is filled from
+ * Gearbox::controller_loop at its native 20 ms period, which is also the period
+ * ShiftingAlgorithm steps at (SHIFT_DELAY_MS), so the capture is lossless with
+ * respect to the algorithm. The host reads the ring out afterwards, in the quiet
+ * time between shifts.
+ *
+ * Nothing here runs inside the shift control path, and the sampler is O(1) with
+ * no allocation.
+ *
+ * Readout: fetch ShiftTraceHeader from RLI_SHIFT_TRACE, then pull samples with
+ * ReadMemoryByAddress using `buffer_addr` (each response carries at most 255
+ * bytes and the host asks for one chunk at a time, so the USB serial bridge's
+ * FIFO is never burst through). `seq` counts every sample ever written, so
+ * sample n is still in the ring while `seq - n < capacity`, which is also how
+ * the host detects an overrun.
+ */
+
+#define SHIFT_TRACE_MAGIC 0x43415254u  // 'TRAC'
+#define SHIFT_TRACE_VERSION 1u
+#define SHIFT_TRACE_CAPACITY 512u      // 512 * 20 ms = 10.2 s of history
+#define SHIFT_TRACE_EVENTS 4u
+
+struct ShiftTraceSample {
+    uint32_t t_ms;          // GET_CLOCK_TIME() when sampled
+    uint16_t input_rpm;
+    uint16_t output_rpm;
+    uint16_t engine_rpm;
+    int16_t  input_torque;
+    uint16_t p_on;          // on clutch pressure  (mBar)
+    uint16_t p_off;         // off clutch pressure (mBar)
+    uint16_t spc;           // corrected shift pressure      (mBar)
+    uint16_t mpc;           // corrected modulating pressure (mBar)
+    uint8_t  phase;         // ShiftingAlgorithm phase id
+    uint8_t  subphase_shift;
+    uint8_t  subphase_mod;
+    uint8_t  flags;         // bit0 shifting, bits 1-4 shift circuit flags
+    uint8_t  pedal;         // raw, 0-250
+    uint8_t  gear;          // actual << 4 | target
+    int16_t  trq_req_amount;// absolute torque asked of the engine, INT16_MAX = no request
+    int16_t  engine_torque; // what the engine reports it is making (CAN static torque)
+} __attribute__((packed));  // 30 bytes
+
+/**
+ * @brief Objective shift quality, computed on the TCU as the shift happens.
+ *
+ * There is no single number for shift quality and no mode-independent one:
+ * Comfort wants low jerk and will pay for it in duration, Agility wants
+ * spontaneity and accepts jerk to get it. So this is a vector, and what counts
+ * as good has to be decided per driving mode by whoever consumes it.
+ *
+ * Nothing in the firmware acts on these - they are recorded so that a shift can be
+ * judged from the car rather than only from an offline log, and so that any
+ * future adaptation has a reward signal to learn against.
+ *
+ * Metrics follow the published ones: jerk is the measure that correlates with
+ * subjective shift feel (SAE 650465), duration is reported with it because a
+ * shift can always be made smooth by making it long, and slip energy is the
+ * wear and thermal load the friction material has to absorb.
+ */
+struct ShiftQuality {
+    uint16_t response_ms;   // request until the ratio actually starts to move
+    uint16_t duration_ms;
+    // mm/s^3 (m/s^3 x1000) of vehicle longitudinal jerk.
+    //
+    // SI, via mps_per_output_rpm(). Converting needs the wheel circumference and
+    // final drive, which the TCU cannot verify - but the error is about 1 % for a
+    // properly plus-sized wheel and 8 % for a 20 inch wheel nobody would fit,
+    // against a metric that reads twice different between 19 Hz and 50 Hz
+    // sampling. Worth it to keep the number comparable with the published
+    // thresholds (comfortable under ~10, objectionable over ~20-30, SAE 650465)
+    // and with whatever target a user sets.
+    // Derivatives are taken over a 3 sample (57 ms) baseline, not one step: the
+    // output speed is quantised to 1 rpm, and a single-step second difference
+    // has a floor of 29.7 m/s^3 on this car, which is above the entire comfort
+    // range. Before that was fixed this field reported its own quantisation.
+    uint16_t peak_jerk;
+    uint16_t torque_hole;   // rpm/s of output shaft accel lost mid-shift
+    uint32_t slip_energy_j; // joules dissipated in the applying clutch
+    uint16_t lockup_rate;   // rpm/s at which the applying clutch slip collapses
+    uint8_t  settle_osc;    // driveline accel reversals after engagement
+    uint8_t  valid;
+} __attribute__((packed));  // 16 bytes
+
+struct ShiftTraceEvent {
+    uint32_t seq_start;     // sample index at which the shift began
+    uint32_t seq_end;       // sample index at which it ended (valid when done)
+    uint8_t  gear_from;
+    uint8_t  gear_to;
+    uint8_t  done;
+    uint8_t  pedal_start;   // accelerator position 0-250 when the shift began
+    ShiftQuality quality;
+} __attribute__((packed));  // 28 bytes
+
+struct ShiftTraceHeader {
+    uint32_t magic;
+    uint8_t  version;
+    uint8_t  sample_size;
+    uint16_t capacity;
+    uint32_t buffer_addr;   // real address of sample 0, for ReadMemoryByAddress
+    uint32_t seq;           // total samples written since boot
+    uint32_t dropped;       // shifts whose window was overwritten before readout
+    uint8_t  n_events;      // number of valid entries in `events`
+    uint8_t  _pad[3];
+    ShiftTraceEvent events[SHIFT_TRACE_EVENTS];
+} __attribute__((packed));
+
+// The host decoder (logger/nag52logger/shift_trace.py) unpacks these by size, and
+// the header carries sample_size so a mismatch is reported rather than silently
+// mis-decoded. Pin them here so the two cannot drift apart unnoticed.
+static_assert(sizeof(ShiftTraceSample) == 30, "ShiftTraceSample must stay 30 bytes");
+static_assert(sizeof(ShiftQuality) == 16, "ShiftQuality must stay 16 bytes");
+static_assert(sizeof(ShiftTraceEvent) == 28, "ShiftTraceEvent must stay 28 bytes");
+static_assert(sizeof(ShiftTraceHeader) == 24 + (28 * SHIFT_TRACE_EVENTS), "ShiftTraceHeader layout changed");
+
+namespace ShiftTrace {
+    /// Allocate the ring. Safe to fail - tracing is then simply inactive.
+    void init(void);
+    /// One sample. Called from Gearbox::controller_loop every 20 ms.
+    void sample(const SensorData* sd, const ShiftAlgoFeedback* algo, bool shifting,
+                uint8_t gear_actual, uint8_t gear_target, uint16_t spc, uint16_t mpc,
+                uint8_t circuit_flags, int16_t trq_req_amount, int16_t engine_torque);
+    /// Header for the diagnostic readout, or nullptr if tracing is inactive.
+    const ShiftTraceHeader* get_header(void);
+
+}
+
+#endif


### PR DESCRIPTION
Adds a high rate shift recorder and an objective shift quality vector, both computed on the TCU. Branched from `dev`, three files touched and three added, +26 lines to existing code.

## Why

The diagnostic link is request/response, so a host poll of the usual record set takes **52.5 ms** — 19 Hz, measured as a median over 29944 cycles across four drives. The sensors and the shift algorithm both update every 20 ms, so polling captures **one update in 2.6** and 62 % of them never leave the TCU.

A shift's inertia phase lasts 100–200 ms. At 19 Hz that is about three aliased samples, which is not enough to see how a shift went. I found this the hard way: a plant model fitted to polled data failed held-out at 161 rpm RMSE with shift durations wrong by 3–10x.

## What it does

A ring in PSRAM is filled from `Gearbox::controller_loop` at its native 20 ms period. That is the same period `ShiftingAlgorithm` steps at, so the capture is lossless with respect to the algorithm and there is no point sampling faster. The host reads the window around each completed shift back afterwards, in the quiet time between shifts.

Nothing runs inside the shift control path. The sampler is O(1) with no allocation, the ring is 512 x 30 bytes in PSRAM (10.2 s of history, 15 KB), and allocation failure is not fatal — tracing is simply inactive and the TCU drives normally.

Alongside the samples it computes a quality vector per completed shift from output shaft acceleration, which is the approach in US 8346444. The metrics are the published ones:

| metric | why |
|---|---|
| `peak_jerk` | SAE 650465 established with the GMR Jerkmeter that this is what correlates with subjective shift feel |
| `duration_ms`, `response_ms` | a shift can always be made smooth by making it long, so quality is low jerk **and** spontaneity (SAE 911938) |
| `slip_energy_j` | wear and thermal load on the friction material |
| `lockup_rate` | a large rate of change of slip at engagement rings the driveline afterwards |
| `torque_hole`, `settle_osc` | the sag, and whether the engagement settled or rang |

Deliberately a vector, not a score. Comfort wants low jerk and will pay for it in duration; Agility wants spontaneity and accepts jerk. A scalar hides exactly the trade being made, so this records the dimensions and leaves the judgement to whoever consumes them.

## Two details that cost real measurements

**Both derivatives span 3 samples (57 ms), not one step.** Output shaft speed is an integer rpm, and differentiating it twice over one 20 ms step has a floor of `1/dt² × metres-per-output-rpm`, which is **29.7 m/s³** on a W210. That is above the entire comfort range, since comfortable is quoted under 10 and objectionable over 20–30. Measured on a real drive, the single-step version reported a median of **30.5** against that floor of 29.7 — its own quantisation, not the shift. Widening to 57 ms divides the floor by nine and still resolves an inertia phase; the same 39 shifts then measure a median of **6.6 m/s³**. Acceleration has the same problem one derivative down, so `torque_hole` is computed the same way.

**Slip energy is gated on the applying clutch actually transmitting.** Integrating through bleed and fill, where slip is largest but the plates are not touching, inflated a gentle 3-4 to 30 kJ. The gate is clutch pressure exceeding its return spring.

## Readout

Fetch `ShiftTraceHeader` from **RLI 0x33**, then pull samples with `ReadMemoryByAddress` using the `buffer_addr` it publishes, one host-paced chunk at a time so the USB serial bridge's FIFO is never burst through. `seq` counts every sample ever written, so sample *n* is still in the ring while `seq - n < capacity`, which is also how the host detects an overrun.

The header carries `sample_size` and a `version` so a host decoder mismatch is reported rather than silently mis-decoded, and `static_assert`s pin the struct sizes on the firmware side.

A reference Python reader lives in my fork under `logger/nag52logger/shift_trace.py`.

## Notes

- Builds clean on `dev` (`pio run -e unified`): flash 40.7 %, RAM 9.0 %.
- Recorded on a W210 EGS51 diesel over several drives. The recorder and the quality maths are vehicle independent; only the numbers quoted above are from that car.
- I dropped the driver-agility field my fork stamps on each event, since that feature is not here. The event carries pedal position at shift start instead.
- Happy to split the quality vector out from the raw recorder if you would rather take them separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
