### PR TITLE
Four small fixes: double-counted release spring, two divide-by-zeros, an OOB index, and a stale engine speed

### DIFF
--- a/src/gearbox.cpp
+++ b/src/gearbox.cpp
@@ -1223,7 +1223,17 @@ void Gearbox::controller_loop()
         tmp_rpm = egs_can_hal->get_engine_rpm(1000);
         if (tmp_rpm == UINT16_MAX)
         {
-            tmp_rpm = this->sensor_data.engine_rpm; // Sub last value!
+            // Substitute the last value for a short while, then treat the engine as
+            // stopped. Substituting indefinitely hides a dead signal, and the
+            // input_rpm == 0 test below cannot catch it while the car is in gear: the
+            // converter drags the turbine to 100-300 rpm at a standstill, so the input
+            // shaft never reads zero there.
+            if (this->engine_rpm_missing_cycles < ENGINE_RPM_MISSING_MAX_CYCLES) {
+                this->engine_rpm_missing_cycles += 1;
+                tmp_rpm = this->sensor_data.engine_rpm; // Sub last value!
+            } else {
+                tmp_rpm = 0;
+            }
             if (sensor_data.input_rpm == 0 && this->engine_running) {
                 // Engine is off, and USB is powering the TCU
                 this->engine_running = false;
@@ -1232,6 +1242,10 @@ void Gearbox::controller_loop()
                 this->actual_gear = GearboxGear::Neutral;
                 this->target_gear = GearboxGear::Neutral;
             }
+        }
+        else
+        {
+            this->engine_rpm_missing_cycles = 0;
         }
         this->sensor_data.engine_rpm = tmp_rpm;
         // Update solenoids, only if engine RPM is OK

--- a/src/gearbox.h
+++ b/src/gearbox.h
@@ -108,6 +108,10 @@ private:
     bool show_upshift = false;
     bool show_downshift = false;
     bool flaring = false;
+    // Cycles of missing engine speed tolerated before it is treated as stopped.
+    // The loop runs at 20 ms, so this is 200 ms.
+    static const uint8_t ENGINE_RPM_MISSING_MAX_CYCLES = 10;
+    uint8_t engine_rpm_missing_cycles = 0;
     bool engine_running = false;
     int gear_disagree_count = 0;
     unsigned long last_tcc_adjust_time = 0;

--- a/src/pressure_manager.cpp
+++ b/src/pressure_manager.cpp
@@ -278,6 +278,9 @@ uint16_t PressureManager::p_clutch_with_coef(GearboxGear gear, Clutch clutch, ui
         default:
             coef = 100.F;
     }
+    if (coef <= 0.F) {
+        coef = 100.F; // Guard a zeroed PRM setting (coefficients are stored x100)
+    }
     float friction_val = MECH_PTR->friction_map[(gear_idx*6)+(uint8_t)clutch];
     if (gear == GearboxGear::Reverse_Second && clutch == Clutch::B3) {
         // Special logic
@@ -304,6 +307,9 @@ int16_t PressureManager::p_clutch_with_coef_signed(GearboxGear gear, Clutch clut
             break;
         default:
             coef = 100.F;
+    }
+    if (coef <= 0.F) {
+        coef = 100.F; // Guard a zeroed PRM setting (coefficients are stored x100)
     }
     float friction_val = MECH_PTR->friction_map[(gear_idx*6)+(uint8_t)clutch];
     float calc = ((float)torque_nm * friction_val) / coef;
@@ -447,11 +453,17 @@ uint16_t PressureManager::calc_max_torque_for_clutch(GearboxGear gear, Clutch cl
         default:
             coef = 100.F;
     }
+    if (coef <= 0.F) {
+        coef = 100.F; // Guard a zeroed PRM setting (coefficients are stored x100)
+    }
     float friction_val = MECH_PTR->friction_map[(gear_idx*6)+(uint8_t)clutch];
     if (gear == GearboxGear::Reverse_Second && clutch == Clutch::B3) {
         // Special logic
         friction_val *= MECH_PTR->friction_map[(2*6)+4];
         friction_val /= MECH_PTR->friction_map[(1*6)+4];
+    }
+    if (friction_val <= 0.F) {
+        return 0; // Clutch is not loaded in this gear - avoid dividing by zero
     }
     float calc = ((float)pressure * coef) / (float)friction_val;
     return calc;
@@ -473,7 +485,13 @@ int PressureManager::calc_max_torque_for_clutch_signed(GearboxGear gear, Clutch 
         default:
             coef = 100.F;
     }
+    if (coef <= 0.F) {
+        coef = 100.F; // Guard a zeroed PRM setting (coefficients are stored x100)
+    }
     float friction_val = MECH_PTR->friction_map[(gear_idx*6)+(uint8_t)clutch];
+    if (friction_val <= 0.F) {
+        return 0; // Clutch is not loaded in this gear - avoid dividing by zero
+    }
     float calc =  ((float)pressure * coef) / (float)friction_val;
     return calc;
 }

--- a/src/shifting_algo/s_algo.cpp
+++ b/src/shifting_algo/s_algo.cpp
@@ -115,7 +115,8 @@ uint8_t ShiftingAlgorithm::step(
 
 uint8_t ShiftingAlgorithm::phase_bleed(PressureManager* pm) {
     uint8_t ret = STEP_RES_CONTINUE;
-    int targ_spc = this->set_p_apply_clutch_with_spring(this->calc_high_filling_p());
+    uint16_t high_fill_p = this->calc_high_filling_p();
+    int targ_spc = this->set_p_apply_clutch_with_spring(high_fill_p);
     if (0 == this->subphase_mod) {
         // Initial variables set
         this->subphase_mod += 1;
@@ -154,7 +155,9 @@ calc_mod:
     }
     else {
         uint16_t mod_with_freewheeling = this->calc_mod_with_filling_trq_and_freewheeling(targ_spc);
-        uint16_t uVar3 = this->calc_mod_min_abs_trq(targ_spc);
+        // Pass the RAW filling pressure: calc_mod_min_abs_trq adds
+        // release_spring_on_clutch itself, and targ_spc already includes it.
+        uint16_t uVar3 = this->calc_mod_min_abs_trq(high_fill_p);
         this->mod_sol_pressure = MAX(mod_with_freewheeling, uVar3);
     }
     return ret;

--- a/src/solenoids/solenoids.cpp
+++ b/src/solenoids/solenoids.cpp
@@ -38,7 +38,10 @@ each channel:
 #define I2S_DMA_BUF_LEN 6 * 200 * SOC_ADC_DIGI_DATA_BYTES_PER_CONV * 2
 uint8_t adc_read_buf[I2S_DMA_BUF_LEN];
 bool first_read_complete = false;
-uint8_t CHANNEL_ID_MAP[ADC_CHANNEL_9] = { 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF };
+// Indexed by the 4 bit channel field of adc_digi_output_data_t, so it has to have
+// 16 entries no matter how many channels are actually configured.
+uint8_t CHANNEL_ID_MAP[16] = { 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
+                               0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF };
 
 void read_solenoids_i2s(void*) {
     PwmSolenoid* const sol_order[6] = { sol_mpc, sol_spc, sol_y3, sol_y4, sol_y5, sol_tcc };
@@ -54,7 +57,7 @@ void read_solenoids_i2s(void*) {
         adc_pattern[i].channel = sol_order[i]->get_adc_channel() & 0x7;
         adc_pattern[i].unit = ADC_UNIT_1;
         adc_pattern[i].bit_width = SOC_ADC_DIGI_MAX_BITWIDTH; // 12bits
-        CHANNEL_ID_MAP[(uint8_t)sol_order[i]->get_adc_channel()] = i;
+        CHANNEL_ID_MAP[(uint8_t)sol_order[i]->get_adc_channel() & 0xF] = i;
     }
     adc_continuous_config_t dig_cfg = {
         .pattern_num = 6,


### PR DESCRIPTION
Four small fixes, one commit each so any can be dropped on its own. Branched from `dev`, 5 files, +47 −5. Builds clean.

Found while merging `dev` into my fork and comparing the two trees line by line, so each one is a place the branches had diverged and `dev`'s side still had the defect.

### 1. The release spring is counted twice in the modulating pressure floor

`phase_bleed` builds `targ_spc` with `set_p_apply_clutch_with_spring`, which adds `release_spring_on_clutch`. It then hands that value to `calc_mod_min_abs_trq`, which adds the same spring again:

```c
int targ_spc = this->set_p_apply_clutch_with_spring(this->calc_high_filling_p());
...
uint16_t uVar3 = this->calc_mod_min_abs_trq(targ_spc);   // adds the spring a second time
```

The other branch of that same `if` is already consistent — `calc_mod_with_filling_trq` and `calc_mod_with_filling_trq_and_freewheeling` both take the spring-inclusive pressure and do not re-add it. Only `calc_mod_min_abs_trq` does, and the centrifugal term gets subtracted twice along with it.

On a 722.6 the release springs are 1139–1289 mBar depending on clutch, so the floor sits roughly a bar high through the bleed phase of every crossover shift.

Fixed by keeping the raw filling pressure in a local and passing that. `calc_mod_min_abs_trq` has no other caller.

### 2. The ADC channel map can be indexed outside itself

`CHANNEL_ID_MAP` is declared with `ADC_CHANNEL_9` entries, i.e. 9, but indexed by `p->type1.channel` from `adc_digi_output_data_t`, which is a 4-bit bitfield holding 0–15.

Latent rather than live: ESP32 ADC1 reports channels 0–7 in normal operation. But it is an out-of-bounds read of a file-scope array whose result then indexes `sol_order`, so it is worth closing. Sized to 16, with the write side masked to match.

### 3. Two divisions that can take a zero

`calc_max_torque_for_clutch` and its signed twin divide by `friction_map[(gear_idx*6)+clutch]`. That map is sparse by design — an entry is zero wherever a clutch is not loaded in that gear. On the calibration I checked against, **26 of its 48 entries are zero**. Asking for the capacity of a clutch outside the power path divides by zero and returns `inf`, which propagates into a pressure. Returning 0 is the true answer: a clutch that carries nothing can hold nothing.

`p_clutch_with_coef` and its signed twin divide by the friction coefficient, which comes straight from the PRM module settings and is user-editable. A coefficient of 0 divides by zero. The switch already falls back to 100 for an unknown `CoefficientTy`; this extends the same fallback to a zeroed setting.

Neither guard changes behaviour on a valid calibration with sane settings — both sit on values that would otherwise produce `inf`.

### 4. A missing engine speed is substituted forever

When `get_engine_rpm` returns SNV the last good value is substituted with no limit, so a signal that never comes back leaves the TCU reporting a stale engine speed indefinitely.

The `input_rpm == 0` branch below is the intended escape, but it cannot fire while the car is in gear: the converter drags the turbine to 100–300 rpm at a standstill, so the input shaft never reads zero there. It only catches the case its comment describes, a TCU powered over USB with the engine off.

Now substitutes for 10 cycles (200 ms at the 20 ms loop period) and then reports 0, which the rest of the code already treats as engine stopped. The counter resets on any valid read, so a single dropped frame behaves exactly as before.

---

Tested to the extent I can without the car connected: builds clean on `dev`, and the shift algorithms still compile and run in my host replay harness against logged shifts. Fixes 1 and 3 change computed pressures on paper; I have not driven them yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
