### PR TITLE
EGS52 bug fixes, pressure management & stability improvements

### DIFF
--- a/lib/core/lookupmap.h
+++ b/lib/core/lookupmap.h
@@ -15,6 +15,7 @@ const int MAX_LOOKUP_CACHE = 5; // I don't think any map has more than this many
 
 class LookupMap {
     public:
+        virtual ~LookupMap() = default;
         float get_value(const float xValue, const float yValue);
         float get_value(const float xValue, const float yValue, const uint8_t lookup_cache_idx);
         void get_y_headers(uint16_t *size, int16_t **headers);
@@ -41,7 +42,7 @@ class LookupAllocMap : public LookupMap {
         LookupAllocMap(const int16_t* _xHeader, const uint16_t _xHeaderSize, const int16_t* _yHeader, const uint16_t _yHeaderSize, const int16_t* _data, const uint16_t _dataSize);
         bool add_data(const int16_t* map, const uint16_t size);
         bool is_allocated(void) const;
-        ~LookupAllocMap();
+        ~LookupAllocMap() override;
 };
 
 class LookupRefMap : public LookupMap {
@@ -54,7 +55,7 @@ class LookupByteMap : public LookupMap {
         LookupByteMap(uint8_t* _xHeader, const uint16_t _xHeaderSize, uint8_t* _yHeader, const uint16_t _yHeaderSize, uint8_t* _data, const uint16_t _dataSize);
         bool is_allocated(void) const;
         bool add_data(const uint8_t* map, const uint16_t size);
-        ~LookupByteMap();
+        ~LookupByteMap() override;
     private:
         int16_t* x_alloc;
         int16_t* y_alloc;

--- a/src/canbus/can_egs52.cpp
+++ b/src/canbus/can_egs52.cpp
@@ -195,7 +195,7 @@ CanTorqueData Egs52Can::get_torque_data(const uint32_t expire_time_ms) {
     if (INT16_MAX != ret.m_converted_static && INT16_MAX != ret.m_converted_driver) {
         int static_converted = ret.m_converted_static;
         int tmp = ret.m_converted_driver;
-        int driver_converted = static_converted;
+        int driver_converted;
         // Calculate converted torque from ESP
         // Chrysler cars don't seem to report MAX/MIN
         if (INT16_MAX != ret.m_max && INT16_MAX != ret.m_min) {

--- a/src/canbus/can_egs53.cpp
+++ b/src/canbus/can_egs53.cpp
@@ -168,7 +168,7 @@ CanTorqueData Egs53Can::get_torque_data(const uint32_t expire_time_ms) {
         // Conversion
         int static_converted = sta;
         int tmp = esp;
-        int driver_converted = static_converted;
+        int driver_converted;
         int indicated = 0;
         // Calculate converted torque from ESP
         // Chrysler cars don't seem to report MAX/MIN

--- a/src/gearbox.cpp
+++ b/src/gearbox.cpp
@@ -614,11 +614,9 @@ void Gearbox::shift_thread()
             uint8_t substage = 0;
             uint8_t timer_s = 0;
             uint8_t timer_m = 0;
-            uint8_t timer_3 = 0;
 
             bool completed_ok = false;
             bool jump_to_pid = false;
-            bool tried_again = false;
             this->algo_feedback.active = true;
             
             while(true) {
@@ -738,7 +736,6 @@ void Gearbox::shift_thread()
                                 } else {
                                     timer_m = timer_s + 80;
                                 }
-                                timer_3 = 80;
                                 substage = 7;
                             }
                         }
@@ -770,7 +767,6 @@ void Gearbox::shift_thread()
                                 } else {
                                     timer_m = timer_s + 80;
                                 }
-                                timer_3 = 80;
                                 substage = 7;
                             }
                         }
@@ -783,10 +779,9 @@ void Gearbox::shift_thread()
                             if (sensor_data.output_rpm < 60) {
                                 timer_m = timer_s + interpolate_float(sensor_data.atf_temp, 40, 7, -30, 20, InterpType::Linear);
                             } else {
-                                timer_m = timer_s + 80;
-                            }
-                            timer_3 = 80;
-                            substage = 7;
+                                                                timer_m = timer_s + 80;
+                                }
+                                substage = 7;
                         }
                     }  else if (substage == 6 || substage == 7) {
                         bool done = false;
@@ -855,7 +850,6 @@ void Gearbox::shift_thread()
                         p_apply_clutch = 0;
                         p_shift = 0;
                         if (0 == timer_s) {
-                            tried_again = true;
                             this->pressure_mgr->set_shift_circuit(ShiftCircuit::sc_3_4, false);
                             this->pressure_mgr->set_shift_circuit(ShiftCircuit::sc_2_3, false);
                             this->pressure_mgr->set_shift_circuit(ShiftCircuit::sc_1_2, false);
@@ -1122,7 +1116,7 @@ void Gearbox::controller_loop()
         }
 
         // Set sensors Motor temperature (Always ran)
-        int16_t coolant_temp = egs_can_hal->get_engine_coolant_temp(50);
+        // int16_t coolant_temp = egs_can_hal->get_engine_coolant_temp(50);
 
         bool speeds_valid = this->process_speed_sensors();
         if (speeds_valid)

--- a/src/gearbox.cpp
+++ b/src/gearbox.cpp
@@ -1711,12 +1711,12 @@ bool Gearbox::calcGearFromRatio(bool is_reverse)
     {
         ratio *= -1;
         for (uint8_t i = 0; i < 2; i++)
-        { // Scan the 2 reverse gears
+        { // Scan the 2 reverse gears (stored in bounds[5] and bounds[6])
             GearRatioInfo limits = gearboxConfig.bounds[i + 5];
             if (ratio >= limits.ratio_min_drift && ratio <= limits.ratio_max_drift)
             {
-                //ESP_LOGI("CGFR", "G %d", i+1);
-                this->est_gear_idx = i + 1;
+                // est_gear_idx must match gear_from_idx(): 6 = Reverse_First, 7 = Reverse_Second
+                this->est_gear_idx = i + 6;
                 return true;
             }
         }

--- a/src/ioexpander.cpp
+++ b/src/ioexpander.cpp
@@ -22,11 +22,11 @@ IOExpander::IOExpander(gpio_num_t sda, gpio_num_t scl)
 			}
 		};
 
-		i2c_master_bus_handle_t bus_handle;
-		init_status = i2c_new_master_bus(&conf, &bus_handle);
+		i2c_master_bus_handle_t temp_bus_handle;
+		init_status = i2c_new_master_bus(&conf, &temp_bus_handle);
 		if (ESP_OK == init_status)
 		{
-			this->bus_handle = bus_handle;
+			this->bus_handle = temp_bus_handle;
 			i2c_device_config_t dev_cfg = {
 				.dev_addr_length = I2C_ADDR_BIT_LEN_7,
 				.device_address = IO_ADDR,
@@ -36,7 +36,7 @@ IOExpander::IOExpander(gpio_num_t sda, gpio_num_t scl)
 					.disable_ack_check = 0
 				}
 			};
-			init_status = i2c_master_bus_add_device(bus_handle, &dev_cfg, &this->dev_handle);
+			init_status = i2c_master_bus_add_device(temp_bus_handle, &dev_cfg, &this->dev_handle);
 			if (ESP_OK == init_status)
 			{
 				// set I/O 1 as output

--- a/src/pressure_manager.cpp
+++ b/src/pressure_manager.cpp
@@ -159,7 +159,12 @@ uint16_t PressureManager::calc_current_linear_sol(uint16_t p_targ, GearboxGear c
     }
 
     int line_pressure = ((int)HYDR_PTR->lp_reg_spring_pressure + (int)this->target_modulating_pressure)*1000;
-    int wp = extra_p + (line_pressure / factor);
+    int wp;
+    if (factor > 0) {
+        wp = extra_p + (line_pressure / factor);
+    } else {
+        wp = extra_p;
+    }
     if (wp <= 0) {
         wp = 0;
     }
@@ -700,11 +705,19 @@ void PressureManager::set_shift_circuit(ShiftCircuit ss, bool enable) {
 }
 
 void PressureManager::set_target_shift_pressure(uint16_t targ) {
+    uint16_t max_p = get_max_solenoid_pressure();
+    if (targ > max_p) {
+        targ = max_p;
+    }
     this->target_shift_pressure = targ;
     this->shift_sol_en = true;
 }
 
 void PressureManager::set_target_modulating_pressure(uint16_t targ) {
+    uint16_t max_p = get_max_solenoid_pressure();
+    if (targ > max_p) {
+        targ = max_p;
+    }
     this->target_modulating_pressure = targ;
 }
 

--- a/src/pressure_manager.cpp
+++ b/src/pressure_manager.cpp
@@ -128,6 +128,7 @@ PressureManager::PressureManager(SensorData* sensor_ptr, uint16_t max_torque) {
     this->target_shift_pressure = this->get_max_solenoid_pressure();
     this->target_modulating_pressure = this->get_max_solenoid_pressure();
     this->target_tcc_pressure = 0;
+    this->currently_open_circuit = ShiftCircuit::None;
 }
 
 uint16_t PressureManager::get_shift_regulator_pressure(void) {

--- a/src/pressure_manager.cpp
+++ b/src/pressure_manager.cpp
@@ -72,7 +72,7 @@ PressureManager::PressureManager(SensorData* sensor_ptr, uint16_t max_torque) {
     default_data = TCC_PWM_MAP;
     tcc_pwm_map = new StoredMap(key_name, TCC_PWM_MAP_SIZE, pwm_tcc_x_headers, pwm_tcc_y_headers, 7, 5, default_data);
     if (this->tcc_pwm_map->init_status() != ESP_OK) {
-        delete[] this->tcc_pwm_map;
+        delete this->tcc_pwm_map;
     }
 
     /** Pressure fill time map **/
@@ -88,7 +88,7 @@ PressureManager::PressureManager(SensorData* sensor_ptr, uint16_t max_torque) {
     default_data = LARGE_NAG_FILL_TIME_MAP;
     fill_time_map = new StoredMap(key_name, FILL_TIME_MAP_SIZE, fill_t_x_headers, fill_t_y_headers, 4, 5, default_data);
     if (this->fill_time_map->init_status() != ESP_OK) {
-        delete[] this->fill_time_map;
+        delete this->fill_time_map;
     }
 
     /** Pressure fill pressure map **/
@@ -105,7 +105,7 @@ PressureManager::PressureManager(SensorData* sensor_ptr, uint16_t max_torque) {
     default_data = NAG_FILL_PRESSURE_MAP;
     fill_pressure_map = new StoredMap(key_name, FILL_PRESSURE_MAP_SIZE, fill_p_x_headers, fill_p_y_headers, 1, 6, default_data);
     if (this->fill_pressure_map->init_status() != ESP_OK) {
-        delete[] this->fill_pressure_map;
+        delete this->fill_pressure_map;
     }
 
     /** Pressure fill pressure map **/
@@ -121,7 +121,7 @@ PressureManager::PressureManager(SensorData* sensor_ptr, uint16_t max_torque) {
     default_data = NAG_FILL_LOW_PRESSURE_MAP;
     fill_low_pressure_map = new StoredMap(key_name, LOW_FILL_PRESSURE_MAP_SIZE, fill_lp_x_headers, fill_lp_y_headers, 1, 5, default_data);
     if (this->fill_low_pressure_map->init_status() != ESP_OK) {
-        delete[] this->fill_low_pressure_map;
+        delete this->fill_low_pressure_map;
     }
 
     // Init MPC and SPC req pressures
@@ -236,9 +236,10 @@ float PressureManager::calculate_centrifugal_force_for_clutch(Clutch clutch, uin
     uint8_t sel_idx = 0xFF;
     float ret = 0;
     switch (clutch) {
-        // OBSERVE. K1 is missing from this list.
-        // on EGS52, it is listed as 0 for the factor table. Perhaps during
-        // testing, they found calculating this force for K1 created some issues?
+        case Clutch::K1:
+            sel_idx = 0;
+            speed = input;
+            break;
         case Clutch::K2:
             sel_idx = 1;
             speed = input;

--- a/src/shifting_algo/s_algo.cpp
+++ b/src/shifting_algo/s_algo.cpp
@@ -98,6 +98,14 @@ uint8_t ShiftingAlgorithm::step(
         this->reset_all_subphase_data();
     }
 
+    // SPC reduction logic (EGS52 0xD490)
+    // Reduce MPC based on active shift pressure to avoid pressure flare/spikes during overlap
+    if (sid->inf.pressure_multi_spc_int != 0) {
+        this->mpc_trq_reducer = (this->shift_sol_pressure * sid->inf.pressure_multi_spc_int) / 1000;
+    } else {
+        this->mpc_trq_reducer = 0;
+    }
+
     // Update output variables
     sid->ptr_w_pressures->shift_sol_req = this->shift_sol_pressure;
     sid->ptr_w_pressures->mod_sol_req = this->mod_sol_pressure;


### PR DESCRIPTION
This PR aggregates a series of bug fixes and stability improvements comparing against the OEM EGS52 reference implementation:

### 1. PressureManager: Centrifugal Force & Memory Fixes
- Added Clutch::K1 to centrifugal force calculation. In EGS52, K1 is indexed at 0 and uses input shaft speed.
- Corrected delete[] to delete on StoredMap instances allocated with new.
- Added virtual ~LookupMap() = default; to base class to ensure safe polymorphic destruction.
- Added override specifiers to derived destructors (LookupAllocMap, LookupByteMap).

### 2. PressureManager: Clamping & Division-by-Zero Safety
- Clamped target_shift_pressure and target_modulating_pressure against get_max_solenoid_pressure() matching EGS52 limit behaviors (0x0d2008).
- Added factor > 0 check in calc_current_linear_sol to prevent division by zero if calibration memory is uninitialized or invalid.
- Initialized currently_open_circuit in constructor.

### 3. ShiftingAlgorithm: MPC Torque Reduction
- Implemented calculation for mpc_trq_reducer using shift_sol_pressure and pressure_multi_spc_int to reduce modulating pressure during overlap, mirroring EGS52's spc_reduction_factor (0xD490).

### 4. Gearbox: Fix Reverse Gear Estimation Bug
- In calcGearFromRatio(is_reverse=true), est_gear_idx was set to i + 1 (indices 1 & 2 = forward 1st/2nd gear). It now correctly sets i + 6 matching gear_from_idx() (indices 6 & 7 = Reverse_First and Reverse_Second).

### 5. Static Analysis & Cleanups
- Fixed shadowing of member variable bus_handle in IOExpander.
- Removed redundant initialization of driver_converted in CAN layers.
- Removed unused local variables in Gearbox controller.
- Verified cleanly with CPPcheck and PlatformIO build (pio run -e unified).